### PR TITLE
Updated Links for jfxcentral2 and jfxcentral-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Welcome to the next version of JFXCentral. This repository contains the codebase
 
 ## Technical vs. Content Issues
 
-If you do encounter any technical issues, then please [create a ticket in this repository](https://github.com/dlemmermann/jfxcentral2/issues). If the issue is related to content then please create the ticket in the issue tracker of the [jfxcentral-data](https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data/issues) repository.
+If you do encounter any technical issues, then please [create a ticket in this repository](https://github.com/dlsc-software-consulting-gmbh/jfxcentral2/issues). If the issue is related to content then please create the ticket in the issue tracker of the [jfxcentral-data](https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data/issues) repository.
 
 ![Screenshot](jfxcentral.jpg)

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/RepositoryManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/RepositoryManager.java
@@ -43,7 +43,7 @@ public class RepositoryManager {
         if (!repoDirectory.exists()) {
             Git.cloneRepository()
                     .setProgressMonitor(monitor)
-                    .setURI("https://github.com/dlemmermann/jfxcentral-data.git") //
+                    .setURI("https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data.git") //
                     .setBranch("live")
                     .setDirectory(repoDirectory)
                     .call();

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
@@ -113,11 +113,11 @@ public class TrayIconManager {
         trayIcon.addSeparator();
 
         MenuItem addInfoToJfxCentral = new MenuItem("Add Info to JFX-Central");
-        addInfoToJfxCentral.setOnAction(evt -> showURL("https://github.com/dlemmermann/jfxcentral-data"));
+        addInfoToJfxCentral.setOnAction(evt -> showURL("https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data"));
         trayIcon.addMenuItem(addInfoToJfxCentral);
 
         MenuItem reportIssue = new MenuItem("Report an Issue");
-        reportIssue.setOnAction(evt -> showURL("https://github.com/dlemmermann/jfxcentral2/issues"));
+        reportIssue.setOnAction(evt -> showURL("https://github.com/dlsc-software-consulting-gmbh/jfxcentral2/issues"));
         trayIcon.addMenuItem(reportIssue);
 
         trayIcon.addSeparator();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/WelcomeView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/WelcomeView.java
@@ -60,12 +60,12 @@ public class WelcomeView extends PaneBase {
         jfxCentralButton.setFocusTraversable(false);
         jfxCentralButton.setGraphic(new FontIcon(IkonUtil.github));
         jfxCentralButton.getStyleClass().addAll("transparent-button", "jfxcentral-button");
-        LinkUtil.setExternalLink(jfxCentralButton, "https://github.com/dlemmermann/jfxcentral2");
+        LinkUtil.setExternalLink(jfxCentralButton, "https://github.com/dlsc-software-consulting-gmbh/jfxcentral2");
 
         jfxcentralDataButton = new Button("jfxcentral-data", new FontIcon(IkonUtil.github));
         jfxcentralDataButton.getStyleClass().addAll("transparent-button", "jfxcentral-data-button");
         jfxcentralDataButton.setFocusTraversable(false);
-        LinkUtil.setExternalLink(jfxcentralDataButton, "https://github.com/dlemmermann/jfxcentral-data");
+        LinkUtil.setExternalLink(jfxcentralDataButton, "https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data");
 
         Region graphicRegion = new Region();
         clientWebSwitchButton = new Button("Install locally", graphicRegion);


### PR DESCRIPTION
1. #433 

 However, I've retained the original link direction in "Stay in loop" for GitHub and made no changes there.
![image](https://github.com/dlsc-software-consulting-gmbh/jfxcentral2/assets/75261429/cbb1b554-63d1-4c52-ba75-9c27f6a8b688)
