### PR TITLE
Add reference documentation page.

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -29,6 +29,7 @@ import com.dlsc.jfxcentral2.app.pages.UserProfilePage;
 import com.dlsc.jfxcentral2.app.pages.category.BlogsCategoryPage;
 import com.dlsc.jfxcentral2.app.pages.category.BooksCategoryPage;
 import com.dlsc.jfxcentral2.app.pages.category.CompaniesCategoryPage;
+import com.dlsc.jfxcentral2.app.pages.category.DocumentationCategoryPage;
 import com.dlsc.jfxcentral2.app.pages.category.DownloadsCategoryPage;
 import com.dlsc.jfxcentral2.app.pages.category.IconsCategoryPage;
 import com.dlsc.jfxcentral2.app.pages.category.LibrariesCategoryPage;
@@ -186,6 +187,7 @@ public class JFXCentral2App extends Application {
                 .and(RouteUtils.get("/links/rss", r -> new LinksOfTheWeekPage(size))) // TODO: how to return raw data?
                 .and(RouteUtils.get("/team", r -> new TeamPage(size)))
                 .and(RouteUtils.get("/openjfx", r -> new OpenJFXPage(size)))
+                .and(RouteUtils.get("/documentation", r -> new DocumentationCategoryPage(size)))
                 .and(RouteUtils.get("/refresh", r -> {
                     RepositoryManager.prepareForRefresh();
                     return new RefreshPage(size);

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
@@ -1,6 +1,7 @@
 package com.dlsc.jfxcentral2.app;
 
 import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.app.utils.OSUtil;
 import com.dlsc.jfxcentral2.utils.PageUtil;
@@ -70,6 +71,7 @@ public class TrayIconManager {
         Menu realWorld = new Menu("Real World Apps");
         Menu tips = new Menu("Tips & Tricks");
         Menu icons = new Menu("Icons");
+        Menu documentation = new Menu("Documentation");
 
         DataRepository2 repository = DataRepository2.getInstance();
 
@@ -84,6 +86,15 @@ public class TrayIconManager {
         repository.getRealWorldApps().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(realWorld, mo));
         repository.getTips().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(tips, mo));
         repository.getIkonliPacks().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(icons, mo));
+        repository.getDocumentation().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(documentation, mo, modelObject -> {
+            try {
+                if (modelObject instanceof Documentation doc) {
+                    Desktop.getDesktop().browse(URI.create(doc.getUrl()));
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }));
         repository.getVideos().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(videos, mo, modelObject -> {
             try {
                 Desktop.getDesktop().browse(URI.create("https://www.youtube.com/watch?v=" + modelObject.getId()));
@@ -106,12 +117,6 @@ public class TrayIconManager {
 
         trayIcon.addSeparator();
 
-        MenuItem cssDocs = new MenuItem("CSS Documentation");
-        cssDocs.setOnAction(evt -> showURL("https://openjfx.io/javadoc/20/javafx.graphics/javafx/scene/doc-files/cssref.html"));
-        trayIcon.addMenuItem(cssDocs);
-
-        trayIcon.addSeparator();
-
         MenuItem addInfoToJfxCentral = new MenuItem("Add Info to JFX-Central");
         addInfoToJfxCentral.setOnAction(evt -> showURL("https://github.com/dlsc-software-consulting-gmbh/jfxcentral-data"));
         trayIcon.addMenuItem(addInfoToJfxCentral);
@@ -120,6 +125,8 @@ public class TrayIconManager {
         reportIssue.setOnAction(evt -> showURL("https://github.com/dlsc-software-consulting-gmbh/jfxcentral2/issues"));
         trayIcon.addMenuItem(reportIssue);
 
+        trayIcon.addSeparator();
+        trayIcon.addMenuItem(documentation);
         trayIcon.addSeparator();
 
         trayIcon.addMenuItem(libraries);
@@ -146,14 +153,14 @@ public class TrayIconManager {
         }
     }
 
-    private void createMenuItem(Menu people, ModelObject mo) {
-        createMenuItem(people, mo, this::showModelObject);
+    private void createMenuItem(Menu menu, ModelObject mo) {
+        createMenuItem(menu, mo, this::showModelObject);
     }
 
-    private void createMenuItem(Menu people, ModelObject mo, Consumer<ModelObject> consumer) {
+    private void createMenuItem(Menu menu, ModelObject mo, Consumer<ModelObject> consumer) {
         MenuItem item = new MenuItem(mo.getName());
         item.setOnAction(evt -> consumer.accept(mo));
-        people.getItems().add(item);
+        menu.getItems().add(item);
     }
 
     private void showModelObject(ModelObject mo) {

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
@@ -1,0 +1,63 @@
+package com.dlsc.jfxcentral2.app.pages.category;
+
+import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.model.Documentation;
+import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
+import com.dlsc.jfxcentral2.components.filters.DocumentationFilterView;
+import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
+import com.dlsc.jfxcentral2.components.tiles.DocumentationTileView;
+import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
+import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.IkonUtil;
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.util.Callback;
+import org.kordamp.ikonli.Ikon;
+
+public class DocumentationCategoryPage extends CategoryPageBase<Documentation> {
+
+    public DocumentationCategoryPage(ObjectProperty<Size> size) {
+        super(size);
+    }
+
+    @Override
+    public String title() {
+        return "JFXCentral - Documentation";
+    }
+
+    @Override
+    public String description() {
+        return "A curated list of documentation for JavaFX and its related topics.";
+    }
+
+    @Override
+    protected String getCategoryTitle() {
+        return "Documentation";
+    }
+
+    @Override
+    protected Ikon getCategoryIkon() {
+        return IkonUtil.getModelIkon(Documentation.class);
+    }
+
+    @Override
+    protected int getNumberOfGridViewRows() {
+        return 5;
+    }
+
+    @Override
+    protected Callback<Documentation, TileViewBase<Documentation>> getTileViewProvider() {
+        return DocumentationTileView::new;
+    }
+
+    @Override
+    protected SearchFilterView<Documentation> createSearchFilterView() {
+        return new DocumentationFilterView();
+    }
+
+    @Override
+    protected ObservableList<Documentation> getCategoryItems() {
+        return FXCollections.observableArrayList(DataRepository2.getInstance().getDocumentation());
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
@@ -210,6 +210,12 @@ public class TopMenuBar extends PaneBase {
             showcasesBtn.getStyleClass().add("showcases-button");
             LinkUtil.setLink(showcasesBtn, "/showcases");
 
+            Button documentationBtn = new Button("Documentation");
+            documentationBtn.setFocusTraversable(false);
+            documentationBtn.setMinWidth(Region.USE_PREF_SIZE);
+            documentationBtn.getStyleClass().add("docs-button");
+            LinkUtil.setLink(documentationBtn, "/documentation");
+
             Button downloadsBtn = new Button("Downloads");
             downloadsBtn.setFocusTraversable(false);
             downloadsBtn.setMinWidth(Region.USE_PREF_SIZE);
@@ -232,7 +238,7 @@ public class TopMenuBar extends PaneBase {
 
             searchField.setVisible(true);
             searchField.setMinWidth(Region.USE_PREF_SIZE);
-            contentBox.getChildren().setAll(logoWrapper, new Spacer(), resourcesBtn, communityBtn, showcasesBtn, downloadsBtn, separatorRegion, loginBtn, searchField);
+            contentBox.getChildren().setAll(logoWrapper, new Spacer(), resourcesBtn, communityBtn, showcasesBtn,documentationBtn, downloadsBtn, separatorRegion, loginBtn, searchField);
         } else {
             Region logoutRegion = new Region();
             logoutRegion.getStyleClass().add("logout-region");

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
@@ -1,0 +1,60 @@
+package com.dlsc.jfxcentral2.components.filters;
+
+import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.model.Documentation;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+public class DocumentationFilterView extends SimpleModelObjectSearchFilterView<Documentation> {
+    private static List<FilterItem<Documentation>> typeFilterItems;
+
+    public DocumentationFilterView() {
+        getStyleClass().addAll("tools-filter-view","doc-filter-view");
+
+        setSearchPromptText("Search for a Documentation");
+
+        setOnSearch(text -> tool -> StringUtils.isBlank(text)
+                || StringUtils.containsIgnoreCase(tool.getName(), text)
+                || StringUtils.containsIgnoreCase(tool.getDescription(), text)
+        );
+
+        if (typeFilterItems == null) {
+            typeFilterItems = getVideoFilterItems(Documentation::getTags, createFilterPredicate(Documentation::getTags));
+        }
+        getFilterGroups().setAll(List.of(
+                new FilterGroup<>("TYPE", typeFilterItems)
+        ));
+    }
+
+    private BiPredicate<Documentation, String> createFilterPredicate(Function<Documentation, String> attrGetter) {
+        return (doc, item) -> {
+            String attribute = attrGetter.apply(doc);
+            return attribute != null && StringUtils.containsIgnoreCase(attribute, item);
+        };
+    }
+    private List<FilterItem<Documentation>> getVideoFilterItems(
+            Function<Documentation, String> attrGetter,
+            BiPredicate<Documentation, String> predicate) {
+        List<Documentation> appList = DataRepository2.getInstance().getDocumentation();
+
+        ArrayList<FilterItem<Documentation>> filterItems = new ArrayList<>(appList.stream()
+                .flatMap(app -> Optional.ofNullable(attrGetter.apply(app)).stream()
+                        .flatMap(attr -> Arrays.stream(attr.split(","))))
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .sorted()
+                .distinct()
+                .map(item -> new FilterItem<Documentation>(item, it -> predicate.test(it, item)))
+                .toList());
+        filterItems.add(0, new FilterItem<>("ALL", item -> true, true));
+
+        return filterItems;
+    }
+}
+

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/hamburger/HamburgerMenuView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/hamburger/HamburgerMenuView.java
@@ -92,17 +92,14 @@ public class HamburgerMenuView extends PaneBase {
         }
 
         HamburgerMenu showcases = new HamburgerMenu("Showcases", "/showcases");
-        showcases.setOnAction(e -> System.out.println("onAction Showcases ..."));
-
+        HamburgerMenu documentation = new HamburgerMenu("Documentation", "/documentation");
         HamburgerMenu downloads = new HamburgerMenu("Downloads", "/downloads");
-        downloads.setOnAction(e -> System.out.println("onAction Downloads ..."));
 
         setMaxHeight(Region.USE_PREF_SIZE);
 
-        if (mobile) {
-            getMenus().addAll(resourcesMenu, communityMenu, showcases);
-        } else {
-            getMenus().addAll(resourcesMenu, communityMenu, showcases, downloads);
+        getMenus().addAll(resourcesMenu, communityMenu, showcases, documentation);
+        if (!mobile) {
+            getMenus().add(downloads);
         }
 
         refreshMenus();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/DocumentationTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/DocumentationTileView.java
@@ -1,0 +1,28 @@
+package com.dlsc.jfxcentral2.components.tiles;
+
+import com.dlsc.jfxcentral.data.ImageManager;
+import com.dlsc.jfxcentral.data.model.Documentation;
+import com.dlsc.jfxcentral2.components.AvatarView;
+import com.dlsc.jfxcentral2.utils.SaveAndLikeUtil;
+
+public class DocumentationTileView extends SimpleTileView<Documentation> {
+
+    public DocumentationTileView(Documentation doc) {
+        super(doc);
+
+        getStyleClass().addAll("tool-tile-view", "doc-tile-view");
+        if ("cssref".equalsIgnoreCase(doc.getId())) {
+            getStyleClass().add("cssref-tile-view");
+        }
+
+        setAvatarType(AvatarView.Type.PLAIN);
+
+        saveAndLikeButton.setSaveButtonSelected(SaveAndLikeUtil.isSaved(doc));
+        saveAndLikeButton.setLikeButtonSelected(SaveAndLikeUtil.isLiked(doc));
+
+        imageProperty().bind(ImageManager.getInstance().documentationImageProperty(doc));
+
+        titleProperty().set(doc.getName());
+        setDescription(doc.getDescription());
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
@@ -2,6 +2,7 @@ package com.dlsc.jfxcentral2.components.tiles;
 
 import com.dlsc.jfxcentral.data.DataRepository2;
 import com.dlsc.jfxcentral.data.model.Book;
+import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral.data.model.Library;
 import com.dlsc.jfxcentral.data.model.ModelObject;
@@ -50,7 +51,7 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
 
         getStyleClass().addAll("simple-tile-view");
 
-        LinkUtil.setLink(this, PageUtil.getLink(item));
+        setLinkForItem(this, item);
 
         AvatarView avatarView = new AvatarView();
         avatarView.imageProperty().bind(imageProperty());
@@ -70,7 +71,7 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
         detailButton.getStyleClass().add("detail-button");
         detailButton.setGraphic(new FontIcon(IkonUtil.link));
         detailButton.setFocusTraversable(false);
-        LinkUtil.setLink(detailButton, PageUtil.getLink(item));
+        setLinkForItem(detailButton, item);
 
         badgeBox.getStyleClass().add("badge-box");
 
@@ -107,6 +108,16 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
         contentBox.getStyleClass().add("content-box");
         getChildren().setAll(contentBox);
     }
+
+    private void setLinkForItem(Node target, ModelObject item) {
+        if (item instanceof Documentation doc) {
+            //The document link is external, and there's no detailed page.
+            LinkUtil.setExternalLink(target, doc.getUrl());
+        } else {
+            LinkUtil.setLink(target, PageUtil.getLink(item));
+        }
+    }
+
 
     public Button getDetailButton() {
         return detailButton;

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonUtil.java
@@ -3,6 +3,7 @@ package com.dlsc.jfxcentral2.utils;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
+import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -17,6 +18,7 @@ import com.dlsc.jfxcentral.data.model.Tutorial;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
 import org.kordamp.ikonli.Ikon;
+import org.kordamp.ikonli.codicons.Codicons;
 import org.kordamp.ikonli.coreui.CoreUiBrands;
 import org.kordamp.ikonli.hawcons.HawconsStroke;
 import org.kordamp.ikonli.lineawesome.LineAwesomeSolid;
@@ -59,6 +61,7 @@ public interface IkonUtil {
     Ikon tutorial = JFXCentralIcon.TUTORIALS;
     Ikon video = JFXCentralIcon.VIDEOS;
     Ikon icons = MaterialDesign.MDI_EMOTICON;
+    Ikon documentation = Codicons.BOOK;
 
     Ikon news = MaterialDesignN.NEWSPAPER_VARIANT_OUTLINE;
     Ikon linkOfTheWeek = JFXCentralIcon.LINKS_OF_THE_WEEK;
@@ -96,7 +99,9 @@ public interface IkonUtil {
             return icons;
         } else if (clazz == News.class) {
             return news;
-        }else {
+        } else if (clazz == Documentation.class) {
+            return documentation;
+        } else {
             return null;
         }
     }

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -3493,6 +3493,17 @@
 }
 
 /** ------------------------------------
+ * DocumentationTileView
+ */
+.doc-tile-view .avatar-view {
+    -fx-avatar-size: 46px;
+}
+
+.doc-tile-view.cssref-tile-view .avatar-view {
+    -fx-avatar-size: 36px;
+}
+
+/** ------------------------------------
  * BlogTileView
  */
 .blog-tile-view .avatar-view {

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
             <dependency>
                 <groupId>com.dlsc.jfxcentral</groupId>
                 <artifactId>model</artifactId>
-                <version>1.19.0</version>
+                <version>1.20.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- #377 

This PR adds a dedicated documentation page aimed at centralizing essential JavaFX development resources. The newly introduced page includes:

CSS Reference Guide: Detailing JavaFX-specific CSS styling nuances.

FXML Reference Documentation: Covering the intricacies of defining UI layouts using FXML.

API Documentation: Serving as a complete reference for JavaFX classes, methods, and functionalities.

Development Handbook: Encompassing best practices, handy tips, and methodical guidance for JavaFX development.

Beginner's Guide: Providing a step-by-step introduction to JavaFX for those new to the framework, helping them get started effectively.

By consolidating these resources in one place, we aim to facilitate a smoother and more comprehensive development experience for both novice and experienced JavaFX developers.