### PR TITLE
FlipPane should create back of pane lazily

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/FlipView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/FlipView.java
@@ -16,12 +16,12 @@ import javafx.css.converter.DurationConverter;
 import javafx.scene.Node;
 import javafx.scene.control.Control;
 import javafx.scene.control.Skin;
-import javafx.scene.layout.StackPane;
 import javafx.util.Duration;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * @author ggrec
@@ -58,32 +58,32 @@ public class FlipView extends ControlBase {
         return flipViewSkin;
     }
 
-    private final ObjectProperty<Node> frontNode = new SimpleObjectProperty<>(this, "frontNode", new StackPane());
+    private final ObjectProperty<Supplier<Node>> frontNodeSupplier = new SimpleObjectProperty<>(this, "frontNode");
 
-    public Node getFrontNode() {
-        return frontNode.get();
+    public Supplier<Node> getFrontNodeSupplier() {
+        return frontNodeSupplier.get();
     }
 
-    public ObjectProperty<Node> frontNodeProperty() {
-        return frontNode;
+    public ObjectProperty<Supplier<Node>> frontNodeSupplierProperty() {
+        return frontNodeSupplier;
     }
 
-    public void setFrontNode(Node frontNode) {
-        this.frontNode.set(frontNode);
+    public void setFrontNodeSupplier(Supplier<Node> frontNodeSupplier) {
+        this.frontNodeSupplier.set(frontNodeSupplier);
     }
 
-    private final ObjectProperty<Node> backNode = new SimpleObjectProperty<>(this, "backNode", new StackPane());
+    private final ObjectProperty<Supplier<Node>> backNodeSupplier = new SimpleObjectProperty<>(this, "backNode");
 
-    public Node getBackNode() {
-        return backNode.get();
+    public Supplier<Node> getBackNodeSupplier() {
+        return backNodeSupplier.get();
     }
 
-    public ObjectProperty<Node> backNodeProperty() {
-        return backNode;
+    public ObjectProperty<Supplier<Node>> backNodeSupplierProperty() {
+        return backNodeSupplier;
     }
 
-    public void setBackNode(Node backNode) {
-        this.backNode.set(backNode);
+    public void setBackNodeSupplier(Supplier<Node> backNodeSupplier) {
+        this.backNodeSupplier.set(backNodeSupplier);
     }
 
     private final StyleableObjectProperty<Duration> flipTime = new SimpleStyleableObjectProperty<>(StyleableProperties.FLIP_TIME, this,

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/TileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/TileView.java
@@ -74,8 +74,9 @@ public class TileView<T extends ModelObject> extends TileViewBase<T> {
         contentBox.setClip(clip);
 
         // [Top] FlipView
-        flipView.frontNodeProperty().bind(Bindings.createObjectBinding(this::createFront, sizeProperty()));
-        flipView.setBackNode(createBack());
+        flipView.frontNodeSupplierProperty().bind(Bindings.createObjectBinding(()->this::createFront, sizeProperty()));
+        flipView.backNodeSupplierProperty().bind(Bindings.createObjectBinding(()->this::createBack, sizeProperty()));
+        flipView.setFocusTraversable(false);
         VBox.setVgrow(flipView, Priority.ALWAYS);
 
         // [Bottom] nodes,save button,like button
@@ -266,11 +267,13 @@ public class TileView<T extends ModelObject> extends TileViewBase<T> {
         closeButton.setContentDisplay(ContentDisplay.RIGHT);
         closeButton.setOnMousePressed(event -> {
             event.consume();
+            flipView.requestFocus();
             flipView.flipToFront();
         });
         closeButton.setFocusTraversable(false);
 
         TextArea descriptionArea = new TextArea();
+        descriptionArea.setFocusTraversable(false);
         descriptionArea.setContextMenu(new ContextMenu());
         descriptionArea.setEditable(false);
         descriptionArea.setWrapText(true);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloFlipView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloFlipView.java
@@ -26,31 +26,41 @@ public class HelloFlipView extends JFXCentralSampleBase {
     protected Region createControl() {
         flipView = new FlipView();
         flipView.getStyleClass().add("hello-flip-view");
-        // create front node
-        ImageView frontImage = new ImageView(new Image(getClass().getResource("/com/dlsc/jfxcentral2/demo/components/images/quick-link-lg1.png").toExternalForm()));
-        frontImage.setPreserveRatio(true);
-        frontImage.setFitWidth(420);
 
-        Button flipToBackBtn = new Button("Click Flip to Back");
-        flipToBackBtn.setOnAction(evt -> flipView.flipToBack());
-        StackPane frontPane = new StackPane(frontImage, flipToBackBtn);
-        StackPane.setAlignment(flipToBackBtn, Pos.TOP_LEFT);
-        StackPane.setMargin(flipToBackBtn, new Insets(10));
+        flipView.setFrontNodeSupplier(()-> {
+            // create front node
+            ImageView frontImage = new ImageView(new Image(getClass().getResource("/com/dlsc/jfxcentral2/demo/components/images/quick-link-lg1.png").toExternalForm()));
+            frontImage.setPreserveRatio(true);
+            frontImage.setFitWidth(420);
 
-        flipView.setFrontNode(frontPane);
+            Button flipToBackBtn = new Button("Click Flip to Back");
+            flipToBackBtn.setOnAction(evt -> flipView.flipToBack());
 
-        // create back node
-        ImageView backImage = new ImageView(new Image(getClass().getResource("/com/dlsc/jfxcentral2/demo/components/images/quick-link-lg2.png").toExternalForm()));
-        backImage.setPreserveRatio(true);
-        backImage.setFitWidth(420);
+            StackPane frontPane = new StackPane(frontImage, flipToBackBtn);
+            StackPane.setAlignment(flipToBackBtn, Pos.TOP_LEFT);
+            StackPane.setMargin(flipToBackBtn, new Insets(10));
+            System.out.println("create front node");
+            return frontPane;
+        });
 
-        Button flipToFrontBtn = new Button("Click Flip to Front");
-        flipToFrontBtn.setOnAction(evt -> flipView.flipToFront());
-        StackPane backPane = new StackPane(backImage, flipToFrontBtn);
-        StackPane.setAlignment(flipToFrontBtn, Pos.TOP_LEFT);
-        StackPane.setMargin(flipToFrontBtn, new Insets(10));
 
-        flipView.setBackNode(backPane);
+
+        flipView.setBackNodeSupplier(()-> {
+            // create back node
+            ImageView backImage = new ImageView(new Image(getClass().getResource("/com/dlsc/jfxcentral2/demo/components/images/quick-link-lg2.png").toExternalForm()));
+            backImage.setPreserveRatio(true);
+            backImage.setFitWidth(420);
+
+            Button flipToFrontBtn = new Button("Click Flip to Front");
+            flipToFrontBtn.setOnAction(evt -> flipView.flipToFront());
+
+            StackPane backPane = new StackPane(backImage, flipToFrontBtn);
+            StackPane.setAlignment(flipToFrontBtn, Pos.TOP_LEFT);
+            StackPane.setMargin(flipToFrontBtn, new Insets(10));
+            System.out.println("create back node");
+            return backPane;
+        });
+
         flipView.setMaxSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
         return new StackPane(flipView);
     }


### PR DESCRIPTION
1. #470 
2. Fixed: despite setting the 'FocusTraversable' attribute of the textarea to 'false', selecting text caused the interface to jump unpredictably when attempting to close it. 