### PR TITLE
Added requested NSBluetoothAlwaysUsageDescription key to Default-Info…

### DIFF
--- a/app/src/ios/Default-Info.plist
+++ b/app/src/ios/Default-Info.plist
@@ -22,6 +22,8 @@
 	<string>APPL</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Please allow bluetooth usage!</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
….plist as requested by Apple review process. I just don't know why :-)