### PR TITLE
Resolve Mobile Node Initialization in SearchTextField and Ensure JVM Exit by Fixing Background ExecutorService

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/CustomSearchField.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/CustomSearchField.java
@@ -1,0 +1,120 @@
+package com.dlsc.jfxcentral2.components;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import org.kordamp.ikonli.Ikon;
+import org.kordamp.ikonli.materialdesign.MaterialDesign;
+
+public class CustomSearchField extends Control {
+
+    private static final String DEFAULT_STYLE_CLASS = "custom-search-field";
+
+    public CustomSearchField() {
+        this(null);
+    }
+
+    public CustomSearchField(String text) {
+        setText(text);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+    }
+
+    public CustomSearchField(boolean round) {
+        this();
+        if (round) {
+            getStyleClass().add("round");
+        }
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new CustomSearchFieldSkin(this);
+    }
+
+    private final ObjectProperty<Ikon> leftIcon = new SimpleObjectProperty<>(this, "leftIcon", MaterialDesign.MDI_MAGNIFY);
+
+    public Ikon getLeftIcon() {
+        return leftIcon.get();
+    }
+
+    public ObjectProperty<Ikon> leftIconProperty() {
+        return leftIcon;
+    }
+
+    public void setLeftIcon(Ikon leftIcon) {
+        this.leftIcon.set(leftIcon);
+    }
+
+    private final ObjectProperty<Runnable> leftIconAction = new SimpleObjectProperty<>(this, "leftIconAction");
+
+    public Runnable getLeftIconAction() {
+        return leftIconAction.get();
+    }
+
+    public ObjectProperty<Runnable> leftIconActionProperty() {
+        return leftIconAction;
+    }
+
+    public void setLeftIconAction(Runnable leftIconAction) {
+        this.leftIconAction.set(leftIconAction);
+    }
+
+    private final ObjectProperty<Ikon> rightIcon = new SimpleObjectProperty<>(this, "rightIcon", MaterialDesign.MDI_CLOSE);
+
+    public Ikon getRightIcon() {
+        return rightIcon.get();
+    }
+
+    public ObjectProperty<Ikon> rightIconProperty() {
+        return rightIcon;
+    }
+
+    public void setRightIcon(Ikon rightIcon) {
+        this.rightIcon.set(rightIcon);
+    }
+
+    private final ObjectProperty<Runnable> rightIconAction = new SimpleObjectProperty<>(this, "rightIconAction", () -> setText(""));
+
+    public Runnable getRightIconAction() {
+        return rightIconAction.get();
+    }
+
+    public ObjectProperty<Runnable> rightIconActionProperty() {
+        return rightIconAction;
+    }
+
+    public void setRightIconAction(Runnable rightIconAction) {
+        this.rightIconAction.set(rightIconAction);
+    }
+
+    private final StringProperty promptText = new SimpleStringProperty(this, "promptText");
+
+    public String getPromptText() {
+        return promptText.get();
+    }
+
+    public StringProperty promptTextProperty() {
+        return promptText;
+    }
+
+    public void setPromptText(String promptText) {
+        this.promptText.set(promptText);
+    }
+
+    private final StringProperty text = new SimpleStringProperty(this, "text");
+
+    public String getText() {
+        return text.get();
+    }
+
+    public StringProperty textProperty() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text.set(text);
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/CustomSearchFieldSkin.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/CustomSearchFieldSkin.java
@@ -1,0 +1,93 @@
+package com.dlsc.jfxcentral2.components;
+
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.TextField;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.StackPane;
+import org.kordamp.ikonli.javafx.FontIcon;
+
+public class CustomSearchFieldSkin extends SkinBase<CustomSearchField> {
+    private final HBox container;
+
+    public CustomSearchFieldSkin(CustomSearchField textField) {
+        super(textField);
+
+        FontIcon leftFontIcon = new FontIcon();
+        leftFontIcon.getStyleClass().add("left-font-icon");
+        leftFontIcon.iconCodeProperty().bind(textField.leftIconProperty());
+
+        StackPane leftPane = new StackPane(leftFontIcon);
+        leftPane.getStyleClass().add("left-wrapper");
+        leftPane.managedProperty().bind(leftPane.visibleProperty());
+        leftPane.visibleProperty().bind(textField.leftIconProperty().isNotNull());
+        leftPane.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> {
+            if (!e.isPrimaryButtonDown()) {
+                return;
+            }
+            Runnable leftIconAction = textField.getLeftIconAction();
+            if (leftIconAction != null) {
+                leftIconAction.run();
+            }
+        });
+
+        FontIcon rightFontIcon = new FontIcon();
+        rightFontIcon.getStyleClass().add("right-font-icon");
+        rightFontIcon.iconCodeProperty().bind(textField.rightIconProperty());
+
+        StackPane rightPane = new StackPane(rightFontIcon);
+        rightPane.getStyleClass().add("right-wrapper");
+        rightPane.visibleProperty().bind(textField.textProperty().isNotEmpty());
+
+        rightPane.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> {
+            if (!e.isPrimaryButtonDown()) {
+                return;
+            }
+            Runnable rightIconAction = textField.getRightIconAction();
+            if (rightIconAction != null) {
+                rightIconAction.run();
+            }
+        });
+
+        TextField innerTextField = new TextField();
+        innerTextField.getStyleClass().add("inner-text-field");
+        innerTextField.textProperty().bindBidirectional(textField.textProperty());
+        innerTextField.promptTextProperty().bind(textField.promptTextProperty());
+        HBox.setHgrow(innerTextField, Priority.ALWAYS);
+
+        container = new HBox();
+        container.getStyleClass().add("container");
+        container.getChildren().addAll(leftPane, innerTextField, rightPane);
+
+        getChildren().add(container);
+    }
+
+    @Override
+    protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
+        double prefWidth = super.computePrefWidth(height - topInset - bottomInset, topInset, rightInset, bottomInset, leftInset);
+        return prefWidth == -1 ? container.prefWidth(height - topInset - bottomInset) + leftInset + rightInset : prefWidth + leftInset + rightInset ;
+    }
+
+    @Override
+    protected double computeMinWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return this.computePrefWidth(height, topInset, rightInset, bottomInset, leftInset);
+    }
+
+    @Override
+    protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
+        double prefHeight = super.computePrefHeight(width - leftInset - rightInset, topInset, rightInset, bottomInset, leftInset);
+        return prefHeight == -1 ? container.prefHeight(width - leftInset - rightInset) + topInset + bottomInset : prefHeight + topInset + bottomInset;
+    }
+
+    @Override
+    protected double computeMaxHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return this.computePrefHeight(width, topInset, rightInset, bottomInset, leftInset);
+    }
+
+    @Override
+    protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
+        return this.computePrefHeight(width, topInset, rightInset, bottomInset, leftInset);
+    }
+
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -1,6 +1,5 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.gemsfx.SearchTextField;
 import com.dlsc.jfxcentral.data.DataRepository2;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
@@ -8,6 +7,7 @@ import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
 import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.DaemonScheduledExecutorService;
 import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
@@ -34,19 +34,18 @@ import org.kordamp.ikonli.Ikon;
 
 import java.util.Comparator;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class PacksIconsView extends PaneBase {
     private static final int SEARCH_DELAY = 200;
-    private final SearchTextField searchField;
+    private final CustomSearchField searchField;
     private final StackPane topWrapper;
     private final HBox sortComboBoxWrapper;
     private final HBox scopeComboBoxWrapper;
     private final StringProperty searchText = new SimpleStringProperty(this, "searchText", "");
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executorService  = DaemonScheduledExecutorService.create();
     private final IkonGridView ikonGridView;
     private final ComboBox<Scope> scopeComboBox;
     private ScheduledFuture<?> future;
@@ -63,7 +62,8 @@ public class PacksIconsView extends PaneBase {
         getStyleClass().addAll("packs-icons-view");
 
         // top
-        searchField = new SearchTextField();
+        searchField = new CustomSearchField(true);
+        searchField.getStyleClass().add("filter-search-field");
         searchField.setFocusTraversable(false);
         searchField.textProperty().addListener((ob, ov, str) -> {
             if (future != null) {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
@@ -1,10 +1,11 @@
 package com.dlsc.jfxcentral2.components.filters;
 
-import com.dlsc.gemsfx.SearchTextField;
+import com.dlsc.jfxcentral2.components.CustomSearchField;
 import com.dlsc.jfxcentral2.components.Header;
 import com.dlsc.jfxcentral2.components.PaneBase;
 import com.dlsc.jfxcentral2.components.Spacer;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
+import com.dlsc.jfxcentral2.utils.DaemonScheduledExecutorService;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
@@ -45,7 +46,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +54,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class SearchFilterView<T> extends PaneBase {
-
     private static final String DEFAULT_STYLE_CLASS = "search-filter-view";
     private static final Orientation FILTER_BOX_DEFAULT_ORIENTATION = Orientation.HORIZONTAL;
     private static final String WITH_SEARCH_FIELD = "with-search-field";
@@ -68,9 +67,10 @@ public class SearchFilterView<T> extends PaneBase {
      * delayed search text
      */
     private final StringProperty searchText = new SimpleStringProperty(this, "searchText", "");
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executorService = DaemonScheduledExecutorService.create();
+
     private ScheduledFuture<?> future;
-    private final SearchTextField searchField = new SearchTextField(true);
+    private final CustomSearchField searchField = new CustomSearchField(true);
     private final StringConverter<FilterItem<T>> predicateItemStringConverter = new StringConverter<>() {
         @Override
         public String toString(FilterItem<T> object) {
@@ -105,6 +105,7 @@ public class SearchFilterView<T> extends PaneBase {
         getStyleClass().add(DEFAULT_STYLE_CLASS);
 
         searchField.setFocusTraversable(false);
+        searchField.getStyleClass().add("filter-search-field");
         searchField.promptTextProperty().bind(searchPromptTextProperty());
         searchField.managedProperty().bind(searchField.visibleProperty());
         searchField.visibleProperty().bind(onSearchProperty().isNotNull());

--- a/components/src/main/java/com/dlsc/jfxcentral2/utilities/paintpicker/impl/NamedColorsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utilities/paintpicker/impl/NamedColorsView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.utilities.paintpicker.impl;
 
-import com.dlsc.gemsfx.SearchTextField;
+import com.dlsc.jfxcentral2.components.CustomSearchField;
 import com.dlsc.jfxcentral2.utilities.paintpicker.impl.datamodel.NamedColor;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -35,7 +35,7 @@ public class NamedColorsView extends VBox {
             tilePane.getChildren().add(rectangle);
         }
 
-        SearchTextField searchField = new SearchTextField();
+        CustomSearchField searchField = new CustomSearchField();
         searchField.setPromptText("Search color");
 
         searchField.textProperty().addListener((observable, oldValue, newValue) -> {

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/DaemonScheduledExecutorService.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/DaemonScheduledExecutorService.java
@@ -1,0 +1,39 @@
+package com.dlsc.jfxcentral2.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A utility class to create a ScheduledExecutorService that uses daemon threads.
+ * Daemon threads do not prevent the JVM from exiting when the program finishes but the thread is still running.
+ */
+public class DaemonScheduledExecutorService {
+    private static final Logger LOGGER = LogManager.getLogger(DaemonScheduledExecutorService.class);
+
+
+    public static ScheduledExecutorService create() {
+        try {
+            return Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory());
+        } catch (Exception e) {
+            LOGGER.error("Failed to create a ScheduledExecutorService", e);
+            throw new RuntimeException("Failed to create a ScheduledExecutorService", e);
+        }
+    }
+
+    private static class DaemonThreadFactory implements ThreadFactory {
+        @Override
+        public Thread newThread(Runnable r) {
+            if (r == null) {
+                LOGGER.error("Runnable is null");
+                throw new NullPointerException("Runnable is null");
+            }
+            Thread thread = new Thread(r);
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}

--- a/components/src/main/java/module-info.java
+++ b/components/src/main/java/module-info.java
@@ -112,6 +112,7 @@ open module com.dlsc.jfxcentral2.components {
     exports com.dlsc.jfxcentral2.utilities.effectdesigner;
     exports com.dlsc.jfxcentral2.utilities.effectdesigner.editor;
     exports com.dlsc.jfxcentral2.utilities.paintpicker.impl;
+    exports com.dlsc.jfxcentral2.utilities.paintpicker.impl.datamodel;
     exports com.dlsc.jfxcentral2.utilities.effectdesigner.effect;
 
     uses IkonProvider;

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -191,6 +191,54 @@
     -fx-alignment: center;
 }
 
+/** ----------------------------------------------------------------------------
+ * CustomSearchField
+ */
+.custom-search-field {
+    -fx-background-color: -white;
+    -fx-background-radius: 2px;
+    -fx-border-color: -grey-30;
+    -fx-border-radius: 2px;
+    -fx-border-width: 1px;
+    -fx-padding: 0.15em 0.4em;
+    -fx-font-size: 16px;
+}
+
+.custom-search-field.round {
+    -fx-background-radius: 1000px;
+    -fx-border-radius: 1000px;
+}
+
+.custom-search-field > .container .inner-text-field {
+    -fx-border-color: transparent;
+    -fx-background-color: transparent;
+    -fx-padding: 0.25em 0.05em;
+}
+
+.custom-search-field > .container .ikonli-font-icon {
+    -fx-icon-size: 17px;
+    -fx-icon-color: -grey-60;
+    -fx-scale-x: 1.2;
+    -fx-scale-y: 1.2;
+}
+
+.custom-search-field > .container .right-wrapper {
+    -fx-cursor: hand;
+}
+
+.custom-search-field > .container .right-wrapper:hover .ikonli-font-icon,
+.custom-search-field > .container .right-wrapper:pressed  .ikonli-font-icon{
+    -fx-icon-color: -grey-100;
+}
+
+.custom-search-field.filter-search-field {
+    -fx-background-radius: 26px;
+    -fx-border-color: transparent;
+    -fx-focus-color: -grey-10;
+    -fx-faint-focus-color: transparent;
+    -fx-padding: 6px 10px;
+}
+
 /** -------------------------------
  * MarkdownView
  */
@@ -5304,18 +5352,6 @@
     -fx-alignment: center;
 }
 
-.search-filter-view .search-text-field {
-    -fx-background-radius: 26px;
-    -fx-focus-color: -grey-10;
-    -fx-faint-focus-color: transparent;
-    -fx-padding: 12px 10px 12px 20px;
-}
-
-.search-filter-view .search-field .graphic-wrapper {
-    -fx-padding: 9px;
-    -fx-background-color: transparent;
-}
-
 .search-filter-view:lg .content-box,
 .search-filter-view:lg .content-box > .filters-box {
     -fx-spacing: 30px;
@@ -5421,20 +5457,6 @@
     -fx-padding: 10px 15px;
 }
 
-.search-filter-view .content-box .search-text-field {
-    -fx-padding: 14px 5px;
-}
-
-.search-filter-view .content-box .search-text-field .clear-icon-wrapper {
-    -fx-cursor: hand;
-}
-
-.search-filter-view .content-box .search-text-field .clear-icon {
-    -fx-cursor: hand;
-    -fx-scale-x: 1.2;
-    -fx-scale-y: 1.2;
-}
-
 .collapsible-button,
 .collapsible-button:focused,
 .collapsible-button:selected {
@@ -5492,7 +5514,7 @@
     -fx-spacing: 30px;
 }
 
-.simple-filter-view:md .search-field {
+.simple-filter-view:md .custom-search-field {
     -fx-pref-width: 385px;
 }
 
@@ -5552,7 +5574,7 @@
     -fx-filter-box-orientation: vertical;
 }
 
-.videos-filter-view:md .search-text-field {
+.videos-filter-view:md .custom-search-field {
     -fx-translate-y: 15px;
 }
 
@@ -5710,11 +5732,11 @@
     -fx-max-width: 1305px;
 }
 
-.showcases-filter-view:lg .search-text-field {
+.showcases-filter-view:lg .custom-search-field {
     -fx-min-width: 210px;
 }
 
-.showcases-filter-view:md .search-text-field {
+.showcases-filter-view:md .custom-search-field {
     -fx-min-width: 200px;
     -fx-translate-y: 15px;
 }
@@ -5727,7 +5749,7 @@
     -fx-filter-box-orientation: vertical;
 }
 
-.showcases-filter-view:md .search-text-field {
+.showcases-filter-view:md .custom-search-field {
     -fx-min-width: 200px;
 }
 
@@ -5816,7 +5838,7 @@
     -fx-pref-width: 248px;
 }
 
-.people-filter-view:lg .content-box .search-field {
+.people-filter-view:lg .content-box .custom-search-field {
     -fx-pref-width: 633px;
 }
 
@@ -5828,7 +5850,7 @@
     -fx-pref-width: 161px;
 }
 
-.people-filter-view:md .content-box .search-field {
+.people-filter-view:md .content-box .custom-search-field {
     -fx-pref-width: 216px;
 }
 
@@ -8765,14 +8787,6 @@
     -fx-alignment: center;
 }
 
-.packs-icons-view .top-box .search-text-field {
-    -fx-background-radius: 26px;
-    -fx-focus-color: -grey-10;
-    -fx-faint-focus-color: transparent;
-    -fx-padding: 12px 10px 12px 20px;
-    -fx-pref-width: 100px;
-}
-
 .packs-icons-view .content-box {
     -fx-alignment: top-center;
 }
@@ -9331,10 +9345,19 @@
 .gradient-designer-view .named-colors-view .top-box {
     -fx-alignment: center;
     -fx-spacing: 15px;
+    -fx-padding: 3px 0 0 0;
 }
 
-.gradient-designer-view .named-colors-view .top-box .search-text-field {
-    -fx-pref-width: 202px;
+.gradient-designer-view .named-colors-view .top-box .custom-search-field {
+    -fx-padding: 0px 5px;
+    -fx-background-radius: 0px;
+    -fx-border-radius: 0px;
+    -fx-border-color: -grey-10;
+}
+
+.gradient-designer-view .named-colors-view .top-box .custom-search-field .inner-text-field {
+    -fx-pref-width: 156px;
+    -fx-max-width: 156px;
 }
 
 .gradient-designer-view .named-colors-view .tile-pane {

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloCustomSearchField.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloCustomSearchField.java
@@ -1,0 +1,18 @@
+package com.dlsc.jfxcentral2.demo.components;
+
+import com.dlsc.jfxcentral2.components.CustomSearchField;
+import com.dlsc.jfxcentral2.demo.JFXCentralSampleBase;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+
+public class HelloCustomSearchField extends JFXCentralSampleBase  {
+    @Override
+    protected Region createControl() {
+        return new StackPane(new CustomSearchField(true));
+    }
+
+    @Override
+    public String getSampleName() {
+        return "CustomSearchField";
+    }
+}


### PR DESCRIPTION
1. Fix SearchTextField Does Not Create Left and Right Nodes on Mobile Devices; #530 
2. Fix Background ExecutorService Prevents JVM Exit; #529 