### PR TITLE
Enhancement icon details page and Update Conveyor config

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -76,6 +76,7 @@ import com.dlsc.jfxcentral2.utils.SocialUtil;
 import com.gluonhq.attach.display.DisplayService;
 import com.jpro.webapi.WebAPI;
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Parent;
@@ -87,6 +88,7 @@ import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Callback;
+import one.jpro.platform.routing.LinkUtil;
 import one.jpro.platform.routing.Request;
 import one.jpro.platform.routing.Response;
 import one.jpro.platform.routing.Route;
@@ -221,6 +223,18 @@ public class JFXCentral2App extends Application {
             stage.setOnCloseRequest(evt -> System.exit(0));
         }
 
+        Desktop desktop = Desktop.getDesktop();
+        if (desktop != null && desktop.isSupported(Desktop.Action.APP_OPEN_URI)) {
+            desktop.setOpenURIHandler(e -> Platform.runLater(() -> {
+                ((Stage) scene.getWindow()).toFront();
+                String uri = e.getURI().toString();
+                String url = StringUtils.substringAfter(uri, "//");
+                LinkUtil.gotoPage(sessionManager, url);
+            }));
+        } else {
+            System.out.println("Does not support opening the custom schema URIs");
+        }
+
         stage.show();
     }
 
@@ -353,7 +367,7 @@ public class JFXCentral2App extends Application {
                     .flatMap(ikonliPack -> IkonliPackUtil.getInstance().getIkon(ikonliPack, iconDescription)
                             .map(ikon -> {
                                 IconInfo iconInfo = new IconInfoBuilder(ikon, ikonliPack.getName(), ikonliPackId).build();
-                                return Response.view(new SingleIconPage(size, iconInfo));
+                                return Response.view(new SingleIconPage(size, iconInfo, true));
                             }))
                     .orElseGet(() -> Response.view(new ErrorPage(size, r)));
         };

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -228,7 +228,7 @@ public class JFXCentral2App extends Application {
             desktop.setOpenURIHandler(e -> Platform.runLater(() -> {
                 ((Stage) scene.getWindow()).toFront();
                 String uri = e.getURI().toString();
-                String url = StringUtils.substringAfter(uri, "//");
+                String url = StringUtils.substringAfter(uri, "/");
                 LinkUtil.gotoPage(sessionManager, url);
             }));
         } else {

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/SingleIconPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/SingleIconPage.java
@@ -13,10 +13,12 @@ import javafx.scene.Node;
 public class SingleIconPage extends PageBase {
 
     private final IconInfo iconInfo;
+    private final boolean isShareable;
 
-    public SingleIconPage(ObjectProperty<Size> size, IconInfo iconInfo) {
+    public SingleIconPage(ObjectProperty<Size> size, IconInfo iconInfo, boolean isShareable) {
         super(size, Mode.DARK);
         this.iconInfo = iconInfo;
+        this.isShareable = isShareable;
     }
 
     @Override
@@ -36,7 +38,7 @@ public class SingleIconPage extends PageBase {
         header.sizeProperty().bind(sizeProperty());
 
         // content
-        IkonDetailView ikonDetailView = new IkonDetailView(iconInfo);
+        IkonDetailView ikonDetailView = new IkonDetailView(iconInfo, isShareable);
         ikonDetailView.sizeProperty().bind(sizeProperty());
 
         PaneBase contentWrapper = new PaneBase();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/gridview/IkonGridView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/gridview/IkonGridView.java
@@ -7,7 +7,7 @@ public class IkonGridView extends SimpleGridView<Ikon> {
     public IkonGridView() {
         getStyleClass().add("ikon-grid-view");
         setCellViewProvider(IkonCellView::new);
-        setDetailNodeProvider(IkonDetailView::new);
+        setDetailNodeProvider(param -> new IkonDetailView(param, false));
         //columnsProperty().bind(sizeProperty().map(s -> s.isLarge() ? 12 : s.isMedium() ? 8 : 3));
         widthProperty().addListener((ob, ov, nv) -> {
             if (nv.doubleValue() != 0) {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/headers/SingleIconDetailHeader.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/headers/SingleIconDetailHeader.java
@@ -18,7 +18,7 @@ public class SingleIconDetailHeader extends DetailHeaderBase {
         String ikonliPackId = iconInfo.getIkonliPackId();
         String ikonliPackName = iconInfo.getIkonliPackName();
 
-        setTitle(iconName);
+        setTitle(iconName.replace("_", " "));
         setIkon(icon);
         setCenter(createCenterNode(iconName, ikonliPackName));
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfo.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfo.java
@@ -13,7 +13,6 @@ public class IconInfo {
     private String mavenInfo;
     private String gradleInfo;
     private String path;
-    private String description;
 
     public IconInfo() {
     }
@@ -96,14 +95,6 @@ public class IconInfo {
 
     public void setPath(String path) {
         this.path = path;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
     }
 
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfoBuilder.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/model/IconInfoBuilder.java
@@ -42,7 +42,6 @@ public class IconInfoBuilder {
 
         // set the icon description
         String description = ikon.getDescription();
-        iconInfo.setDescription(description);
         iconInfo.setIconLiteral(description);
         iconInfo.setCssCode("-fx-icon-code: \"" + description + "\";");
         iconInfo.setJavaCode(ikon.getClass().getSimpleName() + "." + new FontIcon(ikon).getIconCode());

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -8246,29 +8246,44 @@
 }
 
 .ikon-detail-view .ikon-preview-wrapper {
-    -fx-alignment: center;
+    -fx-alignment: center-right;
     -fx-max-width: 120px;
     -fx-spacing: 10px;
 }
 
-.ikon-detail-view .ikon-preview-wrapper > .ikonli-font-icon {
+.ikon-detail-view .ikon-preview .bottom-box {
+    -fx-alignment: center;
+    -fx-spacing: 5px;
+}
+
+.ikon-detail-view:md-lg .ikon-preview .bottom-box {
+    -fx-alignment: center;
+    -fx-font-size: 13px;
+}
+
+.ikon-detail-view .ikon-preview {
+    -fx-alignment: center;
+    -fx-spacing: 10px;
+}
+
+.ikon-detail-view .ikon-preview > .ikonli-font-icon {
     -fx-icon-size: 65px;
     -fx-icon-color: -bright-blue;
 }
 
-.ikon-detail-view:md .ikon-preview-wrapper > .ikonli-font-icon {
+.ikon-detail-view:md .ikon-preview > .ikonli-font-icon {
     -fx-icon-size: 50px;
 }
 
-.ikon-detail-view:sm .ikon-preview-wrapper > .ikonli-font-icon {
+.ikon-detail-view:sm .ikon-preview > .ikonli-font-icon {
     -fx-icon-size: 48px;
 }
 
-.ikon-detail-view:sm .ikon-preview-wrapper .button {
+.ikon-detail-view:sm .ikon-preview .button {
     -fx-font-size: 13px;
 }
 
-.ikon-detail-view.payment-font-detail-view:sm .ikon-preview-wrapper > .ikonli-font-icon {
+.ikon-detail-view.payment-font-detail-view:sm .ikon-preview > .ikonli-font-icon {
     -fx-icon-size: 20px;
 }
 

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -32,9 +32,15 @@ app {
 
   inputs += "app/target/classpath-jars"
   inputs += "app/target/app-*.jar"
+  url-schemes = [${app.fsname}] // For the custom protocol handler.
+  machines = ["mac"] // Only package the Mac version for testing.
 
   jvm {
     gui = com.dlsc.jfxcentral2.app.JFXCentral2App
+
+    system-properties {
+        url.schemes=${app.fsname}
+    }
 
     // Put some things on the module path.
     modules = ${app.jvm.modules} ${temp.icon-font-packs} [

--- a/conveyor.conf
+++ b/conveyor.conf
@@ -33,7 +33,6 @@ app {
   inputs += "app/target/classpath-jars"
   inputs += "app/target/app-*.jar"
   url-schemes = [${app.fsname}] // For the custom protocol handler.
-  machines = ["mac"] // Only package the Mac version for testing.
 
   jvm {
     gui = com.dlsc.jfxcentral2.app.JFXCentral2App


### PR DESCRIPTION
1.  Implemented Detail button for direct access to icon detail pages. 
2. Added URL schemes support. Now, links like `jfxcentral://icons/materialdesign/mdi-check-circle-outline` and `jfxcentral://blogs` can open and navigate within the desktop client to respective resources.