### PR TITLE
Update click handling in list and hyperlinks

### DIFF
--- a/components/src/main/java/com/dlsc/jfxcentral2/components/headers/CategoryHeader.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/headers/CategoryHeader.java
@@ -2,7 +2,6 @@ package com.dlsc.jfxcentral2.components.headers;
 
 import com.dlsc.jfxcentral2.components.Mode;
 import com.dlsc.jfxcentral2.components.PaneBase;
-import com.dlsc.jfxcentral2.utils.OSUtil;
 import com.jpro.webapi.WebAPI;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
@@ -79,7 +78,7 @@ public class CategoryHeader extends PaneBase {
         sizeProperty().addListener((ob, ov, nv) -> getChildren().setAll(overlay, Objects.requireNonNullElse(getContent(), defaultContent)));
 
 
-        if (!WebAPI.isBrowser() && !OSUtil.runningOnMobile()) {
+        if (!WebAPI.isBrowser()) {
             setOnMousePressed(event -> {
                 xOffset = getScene().getWindow().getX() - event.getScreenX();
                 yOffset = getScene().getWindow().getY() - event.getScreenY();

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/MobileLinkUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/MobileLinkUtil.java
@@ -29,7 +29,11 @@ public class MobileLinkUtil {
         } else if (node instanceof Hyperlink hyperlink) {
             hyperlink.setOnAction(e -> getToPage(link));
         } else {
-            node.setOnMousePressed(e -> MobileLinkUtil.getToPage(link));
+            node.setOnMouseClicked(e -> {
+                if (e.isStillSincePress()) {
+                    MobileLinkUtil.getToPage(link);
+                }
+            });
         }
     }
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListCell.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListCell.java
@@ -2,8 +2,6 @@ package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.components.AvatarView;
-import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
-import com.dlsc.jfxcentral2.utils.ModelObjectTool;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
@@ -46,12 +44,6 @@ public class ModelListCell<T extends ModelObject> extends ListCell<T> {
         container.getStyleClass().add("container");
 
         setPrefWidth(0);
-        setOnMouseClicked(event -> {
-            T item = getItem();
-            if (item != null) {
-                MobileLinkUtil.getToPage(ModelObjectTool.getModelLink(item));
-            }
-        });
     }
 
     @Override

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListView.java
@@ -2,6 +2,9 @@ package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.gemsfx.SearchTextField;
 import com.dlsc.jfxcentral.data.model.ModelObject;
+import com.dlsc.jfxcentral2.mobile.utils.ListViewUtil;
+import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
+import com.dlsc.jfxcentral2.utils.ModelObjectTool;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -54,6 +57,9 @@ public class ModelListView<T extends ModelObject> extends VBox {
         listView.setPlaceholder(placeHolderLabel);
         listView.setMaxHeight(Double.MAX_VALUE);
         VBox.setVgrow(listView, Priority.ALWAYS);
+        ListViewUtil.addCellClickHandler(listView, (index, item) -> {
+            MobileLinkUtil.getToPage(ModelObjectTool.getModelLink(item));
+        });
 
         getChildren().setAll(searchWrapper, listView);
         setMaxHeight(Double.MAX_VALUE);
@@ -102,7 +108,7 @@ public class ModelListView<T extends ModelObject> extends VBox {
 
     // comparator
 
-    public final ObjectProperty<Comparator<T>> comparator = new SimpleObjectProperty<>(this, "comparator",  Comparator.comparing((T modelObject) -> StringUtils.defaultIfEmpty(modelObject.getName(),"").toLowerCase()));
+    public final ObjectProperty<Comparator<T>> comparator = new SimpleObjectProperty<>(this, "comparator", Comparator.comparing((T modelObject) -> StringUtils.defaultIfEmpty(modelObject.getName(), "").toLowerCase()));
 
     public final ObjectProperty<Comparator<T>> comparatorProperty() {
         return comparator;

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/utils/ListViewUtil.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/utils/ListViewUtil.java
@@ -1,0 +1,40 @@
+package com.dlsc.jfxcentral2.mobile.utils;
+
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+
+import java.util.function.BiConsumer;
+
+public class ListViewUtil {
+
+    /**
+     * Adds a mouse click event handler to a ListView. The handler is triggered only when the click occurs on a non-empty ListCell
+     * and the mouse has not moved between the press and release of the click. This helps to prevent the handler from being
+     * triggered during a drag gesture.
+     *
+     * @param listView The ListView to which the event handler will be added.
+     * @param action   The action to perform when a click occurs, which accepts two parameters: the index of the ListCell and the item object.
+     * @param <T>      The type of the items in the ListView.
+     */
+    public static <T> void addCellClickHandler(ListView<T> listView, BiConsumer<Integer, T> action) {
+        listView.setOnMouseClicked(event -> {
+            if (!event.isStillSincePress()) {
+                return;
+            }
+
+            Node node = event.getPickResult().getIntersectedNode();
+
+            // Traverse up to find the ListCell or reach the ListView itself
+            while (node != null && node != listView && !(node instanceof ListCell)) {
+                node = node.getParent();
+            }
+
+            // Check if the click is on a ListCell that contains data
+            if (node instanceof ListCell<?> cell && !cell.isEmpty()) {
+                // Execute the defined action
+                action.accept(cell.getIndex(), (T) cell.getItem());
+            }
+        });
+    }
+}


### PR DESCRIPTION
Refactored the event handlers for clicking on list items and hyperlinks. Clicks are now only activated when the mouse has not moved between the press and release events. A new ListViewUtil class has been created to encapsulate this logic for list items, cleaning up code in other areas of the application.