### PR TITLE
Refactor search button functionality in MobileHomePage

### DIFF
--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
@@ -26,12 +26,9 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
-import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
-import org.kordamp.ikonli.fontawesome.FontAwesome;
-import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,28 +69,38 @@ public class MobileHomePage extends VBox {
         header.sizeProperty().bind(sizeProperty());
 
         // search field
-        Button backButton = new Button();
-        backButton.getStyleClass().add("back-button");
-        backButton.setGraphic(new FontIcon(FontAwesome.ANGLE_LEFT));
-        backButton.setOnAction(e -> {
-            searchTextField.clear();
-            setContentType(ContentType.NORMAL);
-        });
-        backButton.managedProperty().bind(backButton.visibleProperty());
-        backButton.visibleProperty().bind(Bindings.createBooleanBinding(() -> getContentType() == ContentType.SEARCH, contentTypeProperty()));
-
         searchTextField = new SearchTextField(true);
-        searchTextField.setRight(new Label("Search"));
+        searchTextField.setRight(createSearchCancelButton());
         searchTextField.setPromptText("Search for anything...");
         searchView.searchTextProperty().bindBidirectional(searchTextField.textProperty());
         searchTextField.setOnMousePressed(event -> setContentType(ContentType.SEARCH));
         searchTextField.textProperty().addListener(it -> setContentType(ContentType.SEARCH));
 
         HBox.setHgrow(searchTextField, Priority.ALWAYS);
-        HBox searchWrapper = new HBox(backButton, searchTextField);
+        HBox searchWrapper = new HBox(searchTextField);
         searchWrapper.getStyleClass().add("search-wrapper");
 
         getChildren().addAll(header, searchWrapper, normalView, searchView);
+    }
+
+    private Button createSearchCancelButton() {
+        Button button = new Button("Search");
+        button.textProperty().bind(Bindings.createStringBinding(() -> {
+            if (getContentType() == ContentType.SEARCH) {
+                return "Cancel";
+            } else {
+                return "Search";
+            }
+        }, contentTypeProperty()));
+        button.setOnAction(event -> {
+            if (getContentType() == ContentType.SEARCH) {
+                searchTextField.clear();
+                setContentType(ContentType.NORMAL);
+            } else {
+                setContentType(ContentType.SEARCH);
+            }
+        });
+        return button;
     }
 
     private Node createNormalView() {

--- a/mobile/src/main/resources/com/dlsc/jfxcentral2/mobile/mobile.css
+++ b/mobile/src/main/resources/com/dlsc/jfxcentral2/mobile/mobile.css
@@ -496,11 +496,12 @@
     -fx-padding: 8px 8px 8px 0;
 }
 
-.mobile-home-page > .search-wrapper > .search-text-field .label {
+.mobile-home-page > .search-wrapper > .search-text-field .button {
     -fx-text-fill: -bright-blue;
-    -fx-padding: 0 5px 0 10px;
+    -fx-padding: 4 5px 4 10px;
     -fx-border-color: -light-blue;
     -fx-border-width: 0 0 0 2px;
+    -fx-background-color: transparent;
 }
 
 .home-page-header {


### PR DESCRIPTION
The existing search button has been replaced with a creatSearchCancelButton method. This button now handles toggling between search and normal content types. Previously unused imports were also removed. Additionally, minor CSS adjustments were made for the search-text-field's button.