### PR TITLE
Simplify MobileCategoryHeader instantiation

### DIFF
--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileCategoryHeader.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileCategoryHeader.java
@@ -4,7 +4,6 @@ import com.dlsc.jfxcentral2.components.AvatarView;
 import com.dlsc.jfxcentral2.components.SizeSupport;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
-import com.dlsc.jfxcentral2.utils.PagePath;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -50,10 +49,6 @@ public class MobileCategoryHeader extends StackPane {
 
         getChildren().addAll(categoryTitle, topBox);
         setMaxHeight(Region.USE_PREF_SIZE);
-    }
-
-    protected String goBackLink() {
-        return PagePath.HOME;
     }
 
     // size support

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBlogDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBlogDetailsPage.java
@@ -25,7 +25,6 @@ public class MobileBlogDetailsPage extends MobileDetailsPageBase<Blog> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().blogIconImageProperty(blog));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(blog.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBlogDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBlogDetailsPage.java
@@ -24,12 +24,7 @@ public class MobileBlogDetailsPage extends MobileDetailsPageBase<Blog> {
         Blog blog = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.BLOGS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().blogIconImageProperty(blog));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(blog.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBookDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBookDetailsPage.java
@@ -26,12 +26,7 @@ public class MobileBookDetailsPage extends MobileDetailsPageBase<Book> {
         Book book = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.BOOKS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         // header.previewImageProperty().bind(ImageManager.getInstance().bookCoverImageProperty(book));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(book.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBookDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileBookDetailsPage.java
@@ -27,7 +27,6 @@ public class MobileBookDetailsPage extends MobileDetailsPageBase<Book> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        // header.previewImageProperty().bind(ImageManager.getInstance().bookCoverImageProperty(book));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(book.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileCompanyDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileCompanyDetailsPage.java
@@ -27,12 +27,7 @@ public class MobileCompanyDetailsPage extends MobileDetailsPageBase<Company> {
         Company company = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.COMPANIES;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.sizeProperty().bind(sizeProperty());
         header.setIcon(IkonUtil.getModelIkon(Company.class));
         header.setTitle(company.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLearnDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLearnDetailsPage.java
@@ -1,14 +1,10 @@
 package com.dlsc.jfxcentral2.mobile.pages.details;
 
 import com.dlsc.jfxcentral.data.model.Learn;
-import com.dlsc.jfxcentral.data.model.LearnJavaFX;
-import com.dlsc.jfxcentral.data.model.LearnMobile;
-import com.dlsc.jfxcentral.data.model.LearnRaspberryPi;
 import com.dlsc.jfxcentral2.components.PrettyScrollPane;
 import com.dlsc.jfxcentral2.components.overviewbox.LearnOverviewBox;
 import com.dlsc.jfxcentral2.mobile.components.MobileCategoryHeader;
 import com.dlsc.jfxcentral2.model.Size;
-import com.dlsc.jfxcentral2.utils.PagePath;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.layout.Priority;
@@ -28,20 +24,7 @@ public class MobileLearnDetailsPage extends MobileDetailsPageBase<Learn> {
         Learn learn = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader() {
-            @Override
-            protected String goBackLink() {
-                Class<? extends Learn> modelClazz = getModelClazz();
-                if (modelClazz == LearnJavaFX.class) {
-                    return PagePath.LEARN_JAVAFX;
-                } else if (modelClazz == LearnRaspberryPi.class) {
-                    return PagePath.LEARN_RASPBERRYPI;
-                } else if (modelClazz == LearnMobile.class) {
-                    return PagePath.LEARN_MOBILE;
-                }
-                return PagePath.HOME;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(learn.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLibraryDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLibraryDetailsPage.java
@@ -27,7 +27,6 @@ public class MobileLibraryDetailsPage extends MobileDetailsPageBase<Library> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().libraryFeaturedImageProperty(library));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(library.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLibraryDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLibraryDetailsPage.java
@@ -26,12 +26,7 @@ public class MobileLibraryDetailsPage extends MobileDetailsPageBase<Library> {
         Library library = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.LIBRARIES;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().libraryFeaturedImageProperty(library));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(library.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobilePersonDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobilePersonDetailsPage.java
@@ -25,12 +25,7 @@ public class MobilePersonDetailsPage extends MobileDetailsPageBase<Person> {
         Person person = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.PEOPLE;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().personImageProperty(person));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(person.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobilePersonDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobilePersonDetailsPage.java
@@ -26,7 +26,6 @@ public class MobilePersonDetailsPage extends MobileDetailsPageBase<Person> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().personImageProperty(person));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(person.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileShowcaseMobileDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileShowcaseMobileDetailsPage.java
@@ -25,7 +25,6 @@ public class MobileShowcaseMobileDetailsPage extends MobileDetailsPageBase<RealW
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().realWorldAppBannerImageProperty(app));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(app.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileShowcaseMobileDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileShowcaseMobileDetailsPage.java
@@ -24,12 +24,7 @@ public class MobileShowcaseMobileDetailsPage extends MobileDetailsPageBase<RealW
         RealWorldApp app = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.SHOWCASES;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().realWorldAppBannerImageProperty(app));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(app.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTipDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTipDetailsPage.java
@@ -27,7 +27,6 @@ public class MobileTipDetailsPage extends MobileDetailsPageBase<Tip> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().tipBannerImageProperty(tip));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tip.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTipDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTipDetailsPage.java
@@ -26,12 +26,7 @@ public class MobileTipDetailsPage extends MobileDetailsPageBase<Tip> {
         Tip tip = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.TIPS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().tipBannerImageProperty(tip));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tip.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileToolDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileToolDetailsPage.java
@@ -27,12 +27,7 @@ public class MobileToolDetailsPage extends MobileDetailsPageBase<Tool> {
         Tool tool = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.TOOLS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().toolImageProperty(tool));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tool.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileToolDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileToolDetailsPage.java
@@ -28,7 +28,6 @@ public class MobileToolDetailsPage extends MobileDetailsPageBase<Tool> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().toolImageProperty(tool));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tool.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTutorialDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTutorialDetailsPage.java
@@ -26,12 +26,7 @@ public class MobileTutorialDetailsPage extends MobileDetailsPageBase<Tutorial> {
         Tutorial tutorial = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.TUTORIALS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().tutorialImageLargeProperty(tutorial));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tutorial.getName());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTutorialDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileTutorialDetailsPage.java
@@ -27,7 +27,6 @@ public class MobileTutorialDetailsPage extends MobileDetailsPageBase<Tutorial> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().tutorialImageLargeProperty(tutorial));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(tutorial.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileVideoDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileVideoDetailsPage.java
@@ -26,7 +26,6 @@ public class MobileVideoDetailsPage extends MobileDetailsPageBase<Video> {
 
         // header
         MobileCategoryHeader header = new MobileCategoryHeader();
-        header.previewImageProperty().bind(ImageManager.getInstance().youTubeImageProperty(video));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(video.getName());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileVideoDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileVideoDetailsPage.java
@@ -6,7 +6,6 @@ import com.dlsc.jfxcentral2.components.PrettyScrollPane;
 import com.dlsc.jfxcentral2.components.overviewbox.VideoOverviewBox;
 import com.dlsc.jfxcentral2.mobile.components.MobileCategoryHeader;
 import com.dlsc.jfxcentral2.model.Size;
-import com.dlsc.jfxcentral2.utils.PagePath;
 import javafx.beans.property.ObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.layout.Priority;
@@ -26,12 +25,7 @@ public class MobileVideoDetailsPage extends MobileDetailsPageBase<Video> {
         Video video = getItem();
 
         // header
-        MobileCategoryHeader header = new MobileCategoryHeader(){
-            @Override
-            protected String goBackLink() {
-                return PagePath.VIDEOS;
-            }
-        };
+        MobileCategoryHeader header = new MobileCategoryHeader();
         header.previewImageProperty().bind(ImageManager.getInstance().youTubeImageProperty(video));
         header.sizeProperty().bind(sizeProperty());
         header.setTitle(video.getName());


### PR DESCRIPTION
1. Remove header image in detail pages
2. Removed redundant overriden method `goBackLink()` from `MobileCategoryHeader` in all details pages. This simplifies how `MobileCategoryHeader` is instantiated, reducing code duplication and making the code more maintainable.
