### PR TITLE
Sort blog posts by date

### DIFF
--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileBlogOverviewBox.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileBlogOverviewBox.java
@@ -65,6 +65,7 @@ public class MobileBlogOverviewBox extends VBox {
                     @Override
                     protected Void call() throws InterruptedException {
                         List<Post> posts = DataRepository2.getInstance().loadPosts(blog);
+                        posts.sort((o1, o2) -> o2.getSyndEntry().getPublishedDate().compareTo(o1.getSyndEntry().getPublishedDate()));
                         Thread.sleep(500);
                         Platform.runLater(() -> {
                             listView.getItems().setAll(posts);


### PR DESCRIPTION
Added a line of code to sort blog posts in descending order based on their published date. This ensures that the most recent posts appear first in the MobileBlogOverviewBox.