### PR TITLE
Add documentation page

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2MobileApp.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2MobileApp.java
@@ -16,6 +16,7 @@ import com.dlsc.jfxcentral.data.model.Tool;
 import com.dlsc.jfxcentral.data.model.Tutorial;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.app.pages.MobileRefreshPage;
+import com.dlsc.jfxcentral2.events.OpenWebLinkEvent;
 import com.dlsc.jfxcentral2.events.RepositoryUpdatedEvent;
 import com.dlsc.jfxcentral2.mobile.components.BottomMenuBar;
 import com.dlsc.jfxcentral2.mobile.components.MobileDevelopToolBar;
@@ -25,6 +26,7 @@ import com.dlsc.jfxcentral2.mobile.pages.MobileLinksOfTheWeekPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileBlogsCategoryPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileBooksCategoryPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileCompaniesCategoryPage;
+import com.dlsc.jfxcentral2.mobile.pages.category.MobileDocPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileLearnJavaFXCategoryPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileLearnMobileCategoryPage;
 import com.dlsc.jfxcentral2.mobile.pages.category.MobileLearnRaspberryPiCategoryPage;
@@ -52,8 +54,10 @@ import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
 import com.dlsc.jfxcentral2.utils.MobileRoute;
 import com.dlsc.jfxcentral2.utils.MobileRouter;
 import com.dlsc.jfxcentral2.utils.NodeUtil;
+import com.dlsc.jfxcentral2.utils.OSUtil;
 import com.dlsc.jfxcentral2.utils.PagePath;
 import com.dlsc.jfxcentral2.utils.Subscribe;
+import com.gluonhq.attach.browser.BrowserService;
 import com.gluonhq.attach.display.DisplayService;
 import fr.brouillard.oss.cssfx.CSSFX;
 import javafx.application.Application;
@@ -70,6 +74,8 @@ import javafx.stage.Stage;
 import javafx.util.Callback;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -148,6 +154,22 @@ public class JFXCentral2MobileApp extends Application {
         notchPane.setManaged(event.isUpdated());
     }
 
+    @Subscribe
+    public void onOpenWebLink(OpenWebLinkEvent event) {
+        String link = event.link();
+        if (OSUtil.isNative()) {
+            BrowserService.create().ifPresent(service -> {
+                try {
+                    service.launchExternalBrowser(link);
+                } catch (IOException | URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } else {
+            getHostServices().showDocument(link);
+        }
+    }
+
     private void updateSizeProperty(Scene scene) {
         double sceneWidth = scene.getWidth();
         if (sceneWidth < 760) {
@@ -176,6 +198,7 @@ public class JFXCentral2MobileApp extends Application {
                 .and(MobileRoute.redirect("/index", PagePath.HOME))
                 .and(MobileRoute.redirect("/home", PagePath.HOME))
                 .and(MobileRoute.get(PagePath.LINKS, r -> new MobileLinksOfTheWeekPage(size)))
+                .and(MobileRoute.get(PagePath.DOCUMENTATION, r -> new MobileDocPage(size)))
                 .and(createCategoryOrDetailRoute(PagePath.SHOWCASES, RealWorldApp.class, () -> new MobileShowcasesCategoryPage(size), id -> new MobileShowcaseMobileDetailsPage(size, id)))
                 .and(createCategoryOrDetailRoute(PagePath.REAL_WORLD, RealWorldApp.class, () -> new MobileShowcasesCategoryPage(size), id -> new MobileShowcaseMobileDetailsPage(size, id)))
                 .and(createCategoryOrDetailRoute(PagePath.LIBRARIES, Library.class, () -> new MobileLibrariesCategoryPage(size), id -> new MobileLibraryDetailsPage(size, id)))

--- a/components/src/main/java/com/dlsc/jfxcentral2/events/OpenWebLinkEvent.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/events/OpenWebLinkEvent.java
@@ -1,0 +1,4 @@
+package com.dlsc.jfxcentral2.events;
+
+public record OpenWebLinkEvent(String link) {
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/MobileLinkUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/MobileLinkUtil.java
@@ -2,6 +2,7 @@ package com.dlsc.jfxcentral2.utils;
 
 
 import com.dlsc.jfxcentral2.components.CustomToggleButton;
+import com.dlsc.jfxcentral2.events.OpenWebLinkEvent;
 import com.dlsc.jfxcentral2.events.MobileLinkEvent;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
@@ -13,6 +14,10 @@ public class MobileLinkUtil {
     private static final EventBus EVENT_BUS = EventBusUtil.getEventBus();
 
     private MobileLinkUtil() {
+    }
+
+    public static void openWebLink(String link) {
+        EVENT_BUS.post(new OpenWebLinkEvent(link));
     }
 
     public static void getToPage(String link) {

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/ModelListView.java
@@ -1,6 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.gemsfx.SearchTextField;
+import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.mobile.utils.ListViewUtil;
 import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
@@ -53,7 +54,11 @@ public class ModelListView<T extends ModelObject> extends VBox {
         listView.setMaxHeight(Double.MAX_VALUE);
         VBox.setVgrow(listView, Priority.ALWAYS);
         ListViewUtil.addCellClickHandler(listView, (index, item) -> {
-            MobileLinkUtil.getToPage(ModelObjectTool.getModelLink(item));
+            if (item instanceof Documentation doc) {
+                MobileLinkUtil.openWebLink(doc.getUrl());
+            } else {
+                MobileLinkUtil.getToPage(ModelObjectTool.getModelLink(item));
+            }
         });
 
         getChildren().setAll(searchWrapper, listView);

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileDocPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileDocPage.java
@@ -1,0 +1,59 @@
+package com.dlsc.jfxcentral2.mobile.pages.category;
+
+import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.ImageManager;
+import com.dlsc.jfxcentral.data.model.Documentation;
+import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
+import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.IkonUtil;
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.image.Image;
+import javafx.util.Callback;
+import org.kordamp.ikonli.Ikon;
+
+public class MobileDocPage extends MobileCategoryPageBase<Documentation> {
+
+    public MobileDocPage(ObjectProperty<Size> size) {
+        super(size);
+        getStyleClass().add("doc-category-page");
+    }
+
+    @Override
+    protected Callback<ListView<Documentation>, ListCell<Documentation>> cellFactory() {
+        return param -> new ModelListCell<>() {
+            @Override
+            protected void handleImage(Documentation item, ObjectProperty<Image> imageProperty) {
+                imageProperty.bind(ImageManager.getInstance().documentationImageProperty(item));
+            }
+
+            @Override
+            protected String getSummary(Documentation item) {
+                return item.getDescription();
+            }
+        };
+    }
+
+    @Override
+    protected String getCategoryTitle() {
+        return "Documentation";
+    }
+
+    @Override
+    protected Ikon getCategoryIkon() {
+        return IkonUtil.getModelIkon(Documentation.class);
+    }
+
+    @Override
+    protected String getSearchPromptText() {
+        return "Search for a documentation";
+    }
+
+    @Override
+    protected ObservableList<Documentation> getCategoryItems() {
+        return FXCollections.observableArrayList(DataRepository2.getInstance().getDocumentation());
+    }
+}


### PR DESCRIPTION
An update has been made to support the opening of documentation links from the mobile application. New classes for handling and dispatching link opening events have been introduced. The functionality caters for either native or external browser link opening, enhancing the user's browsing experience directly from within the app.