### PR TITLE
Implement lifecycle methods for mobile views

### DIFF
--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
@@ -81,6 +81,8 @@ public class MobileHomePage extends MobilePageBase {
         searchWrapper.getStyleClass().add("search-wrapper");
 
         getChildren().addAll(header, searchWrapper, normalView, searchView);
+
+        setViewWillAppear(()-> setContentType(ContentType.NORMAL));
     }
 
     private Button createSearchCancelButton() {

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/skin/MainPageSkin.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/skin/MainPageSkin.java
@@ -1,15 +1,19 @@
 package com.dlsc.jfxcentral2.mobile.skin;
 
+import com.dlsc.jfxcentral2.components.MobilePageBase;
 import com.dlsc.jfxcentral2.events.MobileResponseEvent;
 import com.dlsc.jfxcentral2.events.RepositoryUpdatedEvent;
 import com.dlsc.jfxcentral2.mobile.components.BottomMenuBar;
-import com.dlsc.jfxcentral2.mobile.utils.PreferredFocusedNodeProvider;
 import com.dlsc.jfxcentral2.mobile.pages.MainPage;
+import com.dlsc.jfxcentral2.mobile.utils.PreferredFocusedNodeProvider;
 import com.dlsc.jfxcentral2.utils.EventBusUtil;
 import com.dlsc.jfxcentral2.utils.Subscribe;
 import javafx.scene.Node;
 import javafx.scene.control.SkinBase;
 import javafx.scene.layout.BorderPane;
+
+import java.util.Optional;
+import java.util.function.Function;
 
 public class MainPageSkin extends SkinBase<MainPage> {
 
@@ -29,16 +33,34 @@ public class MainPageSkin extends SkinBase<MainPage> {
 
     @Subscribe
     public void onMobileResponseEvent(MobileResponseEvent event) {
-        Node view = event.mobileResponse().getView();
+        // Old view will disappear
+        Node oldView = borderPane.getCenter();
+        invokeLifecycleMethod(oldView, MobilePageBase::getViewWillDisappear);
 
-        borderPane.setCenter(view);
+        // New view will appear
+        Node newView = event.mobileResponse().getView();
+        invokeLifecycleMethod(newView, MobilePageBase::getViewWillAppear);
+
+        borderPane.setCenter(newView);
+
+        // Old view did disappear
+        invokeLifecycleMethod(oldView, MobilePageBase::getViewDidDisappear);
+
+        // New view did appear
+        invokeLifecycleMethod(newView, MobilePageBase::getViewDidAppear);
 
         // focus the preferred node
-        if (view instanceof PreferredFocusedNodeProvider preferredFocusedNodeProvider) {
+        if (newView instanceof PreferredFocusedNodeProvider preferredFocusedNodeProvider) {
             Node preferredFocusedNode = preferredFocusedNodeProvider.getPreferredFocusedNode();
             if (preferredFocusedNode != null) {
                 preferredFocusedNode.requestFocus();
             }
+        }
+    }
+    
+    private void invokeLifecycleMethod(Node view, Function<MobilePageBase, Runnable> eventFunction) {
+        if (view instanceof MobilePageBase mobilePage) {
+            Optional.ofNullable(eventFunction.apply(mobilePage)).ifPresent(Runnable::run);
         }
     }
 


### PR DESCRIPTION
The update incorporates lifecycle methods for mobile views in the MainPageSkin class. Now, before an old view disappears or a new view appears, optional Runnable tasks are executed. This allows for smoother transitions between different views. A viewDidLoad method was also added to the MobileHomePage class for setting the content type on view appearance.