### PR TITLE
Add first-time setup and update UI to MobileRefreshPage

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/MobileRefreshPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/MobileRefreshPage.java
@@ -15,6 +15,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
@@ -35,6 +36,7 @@ public class MobileRefreshPage extends StackPane {
 
     private final WeakInvalidationListener weakInvalidationListener = new WeakInvalidationListener(invalidationListener);
     private final RepositoryUpdater repositoryUpdater = new RepositoryUpdater();
+    private final CustomImageView logo;
 
     public MobileRefreshPage(ObjectProperty<Size> size) {
         getStyleClass().add(DEFAULT_STYLE_CLASS);
@@ -44,10 +46,19 @@ public class MobileRefreshPage extends StackPane {
             invalidationListener.invalidated(null);
         });
 
-        // top part (logo)
-        CustomImageView logo = new CustomImageView();
+        logo = new CustomImageView();
         logo.getStyleClass().addAll("jfx-central-logo", "color");
 
+        boolean firstTimeSetup = RepositoryManager.isFirstTimeSetup();
+
+        if (firstTimeSetup) {
+            setupFirstTimeUI();
+        } else {
+            setupUpdateUI();
+        }
+    }
+
+    private void setupFirstTimeUI() {
         // center part (intro pane)
         IntroPane introPane = new IntroPane();
         VBox.setVgrow(introPane, Priority.ALWAYS);
@@ -72,8 +83,8 @@ public class MobileRefreshPage extends StackPane {
         // bottom part
         Button startButton = new Button("Get Started");
         startButton.getStyleClass().add("start-button");
-        startButton.setVisible(RepositoryManager.isFirstTimeSetup());
-        startButton.setVisible(RepositoryManager.isFirstTimeSetup());
+        startButton.setVisible(true);
+        startButton.setVisible(true);
         startButton.setOnAction(evt -> {
             startButton.setVisible(false);
             startButton.setManaged(false);
@@ -88,10 +99,22 @@ public class MobileRefreshPage extends StackPane {
         VBox content = new VBox(logo, introPane, bottomBox);
         content.getStyleClass().add("content-box");
         getChildren().add(content);
+    }
 
-        if (!RepositoryManager.isFirstTimeSetup()) {
-            repositoryUpdater.performUpdate(true);
-        }
+    private void setupUpdateUI() {
+        Label tipsLabel = new Label("Checking for updates ...");
+
+        Region dividingLine = new Region();
+        dividingLine.getStyleClass().add("dividing-line");
+
+        VBox updateContentBox = new VBox(logo, dividingLine, tipsLabel);
+        updateContentBox.getStyleClass().add("update-content-box");
+        updateContentBox.setMaxHeight(Region.USE_PREF_SIZE);
+
+        getChildren().add(updateContentBox);
+
+        // start the update process
+        repositoryUpdater.performUpdate(true);
     }
 
 }

--- a/mobile/src/main/resources/com/dlsc/jfxcentral2/mobile/mobile.css
+++ b/mobile/src/main/resources/com/dlsc/jfxcentral2/mobile/mobile.css
@@ -1065,6 +1065,28 @@
     -fx-border-width: 0 0 1px 0;
 }
 
+.mobile-refresh-page .update-content-box {
+    -fx-alignment: center;
+    -fx-padding: 0 50px;
+    -fx-spacing: 5px;
+}
+
+.mobile-refresh-page .update-content-box .custom-image-view {
+    -fx-fit-width: 400px;
+}
+
+.mobile-refresh-page .update-content-box .dividing-line {
+    -fx-border-color: #75767660;
+    -fx-border-width: 0 0 1px 0;
+    -fx-padding: 0 0 10px 0;
+}
+
+.mobile-refresh-page .update-content-box > .label {
+    -fx-font-family: "Roboto Condensed";
+    -fx-font-size: 1.3em;
+    -fx-text-fill: -grey-30;
+}
+
 /** ----------------------------------
  * IntroPane
  */


### PR DESCRIPTION
Refactored MobileRefreshPage to initialize UI based on first-time setup or update mode. Introduced `setupFirstTimeUI` and `setupUpdateUI` methods to separate logic. Updated CSS to style the new update UI elements.