### PR TITLE
Configure GraalVM and JDK in iOS workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
+        graalvm: '22.1.0.1-Final'
+        jdk: 'java17'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Added specific versions for GraalVM and JDK to the iOS GitHub Actions workflow. This ensures consistent build environments and enhances compatibility with the project's requirements.