### PR TITLE
Fix GraalVM setup syntax in iOS workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,8 +12,9 @@ jobs:
 
       - name: Setup Gluon's GraalVM
         uses: gluonhq/setup-graalvm@master
-        graalvm: '22.1.0.1-Final'
-        jdk: 'java17'
+        with:
+          graalvm: '22.1.0.1-Final'
+          jdk: 'java17'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Updated the iOS GitHub Actions workflow to correct the syntax for setting up Gluon's GraalVM. This change shifts from using direct assignment to the `with` parameter block for better compatibility and clarity.