### PR TITLE
Remove iPad support key from iOS plist.

### DIFF
--- a/app/src/ios/Default-Info.plist
+++ b/app/src/ios/Default-Info.plist
@@ -44,7 +44,6 @@
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>
-		<integer>2</integer>
 	</array>
 	<key>MinimumOSVersion</key>
 	<string>11.0</string>


### PR DESCRIPTION
This commit removes the `<integer>2</integer>` key from the `UIDeviceFamily` array in the iOS `Default-Info.plist` file. This change indicates that the app no longer supports iPad devices, focusing solely on iPhone compatibility.