### PR TITLE
Change DataRepository2 references to DataRepository

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.app;
 
 import com.dlsc.gemsfx.util.StageManager;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -328,7 +328,7 @@ public class JFXCentral2App extends Application {
         int index = request.getPath().lastIndexOf("/");
         if (index > 0) {
             String id = request.getPath().substring(index + 1).trim();
-            if (!DataRepository2.getInstance().isValidId(clazz, id)) {
+            if (!DataRepository.getInstance().isValidId(clazz, id)) {
                 return Response.view(new ErrorPage(size, request));
             }
 
@@ -360,7 +360,7 @@ public class JFXCentral2App extends Application {
             String ikonliPackId = parts[1];
             String iconDescription = parts[2];
 
-            return DataRepository2.getInstance().getIkonliPackById(ikonliPackId)
+            return DataRepository.getInstance().getIkonliPackById(ikonliPackId)
                     .flatMap(ikonliPack -> IkonliPackUtil.getInstance().getIkon(ikonliPack, iconDescription)
                             .map(ikon -> {
                                 IconInfo iconInfo = new IconInfoBuilder(ikon, ikonliPack.getName(), ikonliPackId).build();

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2MobileApp.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2MobileApp.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -220,7 +220,7 @@ public class JFXCentral2MobileApp extends Application {
             int index = url.lastIndexOf("/");
             if (index > 0 && clazz != null) {
                 String id = url.substring(index + 1).trim();
-                if (!DataRepository2.getInstance().isValidId(clazz, id)) {
+                if (!DataRepository.getInstance().isValidId(clazz, id)) {
                     return MobileResponse.view(url, new Label("Error: 404"));
                 }
                 return MobileResponse.view(url, detailedResponse.call(id));

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/RepositoryManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/RepositoryManager.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.utils.LOGGER;
 import com.dlsc.jfxcentral2.utils.OSUtil;
 import javafx.application.Platform;
@@ -62,7 +62,7 @@ public class RepositoryManager {
     }
 
     private static File getRepositoryDirectory() {
-        return DataRepository2.getRepositoryDirectory();
+        return DataRepository.getInstance().getRepositoryDirectory();
     }
 
     public static boolean isFirstTimeSetup() {

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/TrayIconManager.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.utils.LOGGER;
@@ -76,7 +76,7 @@ public class TrayIconManager {
         Menu utilities = new Menu("Utilities");
         Menu documentation = new Menu("Documentation");
 
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
 
         repository.getTools().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(tools, mo));
         repository.getPeople().stream().sorted(Comparator.comparing(ModelObject::getName)).forEach(mo -> createMenuItem(people, mo));

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/DetailsPageBase.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/DetailsPageBase.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -51,7 +51,7 @@ public abstract class DetailsPageBase<T extends ModelObject> extends PageBase {
 
     public DetailsPageBase(ObjectProperty<Size> size, Class<? extends T> clazz, String itemId) {
         super(size, Mode.DARK);
-        setItem(DataRepository2.getInstance().getByID(clazz, itemId));
+        setItem(DataRepository.getInstance().getByID(clazz, itemId));
     }
 
     public T getItem() {
@@ -120,7 +120,7 @@ public abstract class DetailsPageBase<T extends ModelObject> extends PageBase {
             return;
         }
 
-        List<MO> linkedObjects = DataRepository2.getInstance().getLinkedObjects(modelObject, clazz);
+        List<MO> linkedObjects = DataRepository.getInstance().getLinkedObjects(modelObject, clazz);
         if (!linkedObjects.isEmpty()) {
             DetailsBoxBase<MO> box = boxSupplier.get();
             box.getItems().setAll(linkedObjects);
@@ -130,9 +130,9 @@ public abstract class DetailsPageBase<T extends ModelObject> extends PageBase {
     }
 
     private void addLearnBox(ModelObject modelObject, List<DetailsBoxBase<?>> boxList) {
-        List<LearnJavaFX> fxList = DataRepository2.getInstance().getLinkedObjects(modelObject, LearnJavaFX.class);
-        List<LearnMobile> mobileList = DataRepository2.getInstance().getLinkedObjects(modelObject, LearnMobile.class);
-        List<LearnRaspberryPi> learnRaspberryPiList = DataRepository2.getInstance().getLinkedObjects(modelObject, LearnRaspberryPi.class);
+        List<LearnJavaFX> fxList = DataRepository.getInstance().getLinkedObjects(modelObject, LearnJavaFX.class);
+        List<LearnMobile> mobileList = DataRepository.getInstance().getLinkedObjects(modelObject, LearnMobile.class);
+        List<LearnRaspberryPi> learnRaspberryPiList = DataRepository.getInstance().getLinkedObjects(modelObject, LearnRaspberryPi.class);
         if (!fxList.isEmpty() || !mobileList.isEmpty() || !learnRaspberryPiList.isEmpty()) {
             LearnDetailBox box = new LearnDetailBox();
             box.getItems().setAll(fxList);

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.DetailsContentPane;
 import com.dlsc.jfxcentral2.components.LinksOfTheWeekView;
@@ -67,7 +67,7 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
 
         // links of the week view
         LinksOfTheWeekView linksOfTheWeekView = new LinksOfTheWeekView();
-        linksOfTheWeekView.getLinksOfTheWeeks().setAll(DataRepository2.getInstance().getLinksOfTheWeek());
+        linksOfTheWeekView.getLinksOfTheWeeks().setAll(DataRepository.getInstance().getLinksOfTheWeek());
         linksOfTheWeekView.sizeProperty().bind(sizeProperty());
 
         // this is a category page, but we still need to use the details content pane for layout purposes
@@ -130,7 +130,7 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
 
     @Override
     protected ObservableList<LinksOfTheWeek> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLinksOfTheWeek());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLinksOfTheWeek());
     }
 
     @Override
@@ -144,7 +144,7 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
     }
 
     protected List<MenuView.Item> createMenuItems(LinksOfTheWeekView linksOfTheWeekView) {
-        List<LinksOfTheWeek> linksOfTheWeek = DataRepository2.getInstance().getLinksOfTheWeek();
+        List<LinksOfTheWeek> linksOfTheWeek = DataRepository.getInstance().getLinksOfTheWeek();
         List<LinksOfTheWeek> weeks = new ArrayList<>(linksOfTheWeek);
 
         return weeks

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/StartPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/StartPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.HomePageTopView;
 import com.dlsc.jfxcentral2.components.Mode;
@@ -38,7 +38,7 @@ public class StartPage extends PageBase {
         homePageTopView.sizeProperty().bind(sizeProperty());
 
         // links of the Week
-        List<LinksOfTheWeek> linksOfTheWeek = DataRepository2.getInstance().getLinksOfTheWeek();
+        List<LinksOfTheWeek> linksOfTheWeek = DataRepository.getInstance().getLinksOfTheWeek();
 
         WeekLinksLiteView weekLinksLiteView = new WeekLinksLiteView();
         weekLinksLiteView.sizeProperty().bind(sizeProperty());
@@ -56,7 +56,7 @@ public class StartPage extends PageBase {
         // video gallery
         VideoGalleryView videoGallery = new VideoGalleryView();
         videoGallery.sizeProperty().bind(sizeProperty());
-        videoGallery.getVideos().setAll(randomSubList(DataRepository2.getInstance().getVideos(), 12));
+        videoGallery.getVideos().setAll(randomSubList(DataRepository.getInstance().getVideos(), 12));
         videoGallery.blockingProperty().addListener(it -> setBlocking(videoGallery.isBlocking()));
         videoGallery.onCloseGlassPaneProperty().addListener(it -> setOnCloseGlassPane(videoGallery.getOnCloseGlassPane()));
         return wrapContent(homePageTopView, weekLinksLiteView, websiteChangesView, videoGallery);

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/TeamPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/TeamPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.components.FeaturesContainer;
 import com.dlsc.jfxcentral2.components.Mode;
 import com.dlsc.jfxcentral2.components.StripView;
@@ -39,7 +39,7 @@ public class TeamPage extends PageBase {
         // team view
         TeamView teamView = new TeamView();
         teamView.sizeProperty().bind(sizeProperty());
-        teamView.getMembers().setAll(DataRepository2.getInstance().getMembers());
+        teamView.getMembers().setAll(DataRepository.getInstance().getMembers());
 
         // features
         FeaturesContainer featuresContainer = new FeaturesContainer();

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BlogsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BlogsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.BlogsFilterView;
@@ -63,6 +63,6 @@ public class BlogsCategoryPage extends CategoryPageBase<Blog> {
 
     @Override
     protected ObservableList<Blog> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getBlogs());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getBlogs());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BooksCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BooksCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.BooksFilterView;
@@ -61,6 +61,6 @@ public class BooksCategoryPage extends CategoryPageBase<Book> {
 
     @Override
     protected ObservableList<Book> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getBooks());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getBooks());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/CompaniesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/CompaniesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Company;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.CompaniesFilterView;
@@ -58,6 +58,6 @@ public class CompaniesCategoryPage extends CategoryPageBase<Company> {
 
     @Override
     protected ObservableList<Company> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getCompanies());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getCompanies());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.DocumentationFilterView;
@@ -63,6 +63,6 @@ public class DocumentationCategoryPage extends CategoryPageBase<Documentation> {
 
     @Override
     protected ObservableList<Documentation> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getDocumentation());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getDocumentation());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DownloadsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DownloadsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.DownloadsBox;
@@ -63,7 +63,7 @@ public class DownloadsCategoryPage extends CategoryPageBase<Download> {
 
     @Override
     protected ObservableList<Download> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getDownloads());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getDownloads());
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnJavaFXCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnJavaFXCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -35,7 +35,7 @@ public class LearnJavaFXCategoryPage extends LearnCategoryPage {
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnJavaFX());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnJavaFX());
     }
 
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnMobileCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnMobileCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -36,6 +36,6 @@ public class LearnMobileCategoryPage extends LearnCategoryPage {
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnMobile());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnMobile());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnRaspberryPiCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnRaspberryPiCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -36,6 +36,6 @@ public class LearnRaspberryPiCategoryPage extends LearnCategoryPage {
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnRaspberryPi());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnRaspberryPi());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LibrariesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LibrariesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Library;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.LibrariesFilterView;
@@ -67,6 +67,6 @@ public class LibrariesCategoryPage extends CategoryPageBase<Library> {
 
     @Override
     protected ObservableList<Library> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLibraries());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLibraries());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/PeopleCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/PeopleCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.PeopleFilterView;
@@ -77,6 +77,6 @@ public class PeopleCategoryPage extends CategoryPageBase<Person> {
 
     @Override
     protected ObservableList<Person> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getPeople());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getPeople());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ShowcasesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ShowcasesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -58,6 +58,6 @@ public class ShowcasesCategoryPage extends CategoryPageBase<RealWorldApp> {
 
     @Override
     protected ObservableList<RealWorldApp> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getRealWorldApps());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getRealWorldApps());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TipCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TipCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tip;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -58,6 +58,6 @@ public class TipCategoryPage extends CategoryPageBase<Tip> {
 
     @Override
     protected ObservableList<Tip> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTips());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTips());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ToolsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ToolsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tool;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -63,6 +63,6 @@ public class ToolsCategoryPage extends CategoryPageBase<Tool> {
 
     @Override
     protected ObservableList<Tool> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTools());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTools());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TutorialsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TutorialsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tutorial;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -58,6 +58,6 @@ public class TutorialsCategoryPage extends CategoryPageBase<Tutorial> {
 
     @Override
     protected ObservableList<Tutorial> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTutorials());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTutorials());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/UtilitiesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/UtilitiesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Utility;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -66,7 +66,7 @@ public class UtilitiesCategoryPage extends CategoryPageBase<Utility> {
 
     @Override
     protected ObservableList<Utility> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getUtilities())
+        return FXCollections.observableArrayList(DataRepository.getInstance().getUtilities())
                 .sorted((o1, o2) -> Boolean.compare(o2.isOnlineSupported(), o1.isOnlineSupported()));
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/VideosCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/VideosCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.app.pages.CategoryPageBase;
 import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
@@ -69,6 +69,6 @@ public class VideosCategoryPage extends CategoryPageBase<Video> {
 
     @Override
     protected ObservableList<Video> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getVideos());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getVideos());
     }
 }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/service/LoadPullRequestsService.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/service/LoadPullRequestsService.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.service;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.pull.PullRequest;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
@@ -14,7 +14,7 @@ public class LoadPullRequestsService extends Service<List<PullRequest>> {
         return new Task<>() {
             @Override
             protected List<PullRequest> call() {
-                List<PullRequest> pullRequests = DataRepository2.getInstance().loadPullRequests();
+                List<PullRequest> pullRequests = DataRepository.getInstance().loadPullRequests();
                 updateProgress(1, 1);
                 return pullRequests;
             }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/utils/RepositoryUpdater.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/utils/RepositoryUpdater.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.app.utils;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.app.RepositoryManager;
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyIntegerProperty;
@@ -63,7 +63,7 @@ public class RepositoryUpdater {
             @Override
             public void endTask() {
                 if (refresh) {
-                    DataRepository2.getInstance().reload();
+                    DataRepository.getInstance().reload();
                 }
             }
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/FeaturesContainer.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/FeaturesContainer.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -61,21 +61,21 @@ public class FeaturesContainer extends PaneBase {
         featuresProperty().addListener((ob, ov, nv) -> layoutBySize());
 
         List<ModelObject> allModelObjects = new ArrayList<>();
-        allModelObjects.addAll(DataRepository2.getInstance().getTips());
-        allModelObjects.addAll(DataRepository2.getInstance().getLibraries());
-        allModelObjects.addAll(DataRepository2.getInstance().getRealWorldApps());
-        allModelObjects.addAll(DataRepository2.getInstance().getTools());
-        allModelObjects.addAll(DataRepository2.getInstance().getBooks());
-        allModelObjects.addAll(DataRepository2.getInstance().getBlogs());
+        allModelObjects.addAll(DataRepository.getInstance().getTips());
+        allModelObjects.addAll(DataRepository.getInstance().getLibraries());
+        allModelObjects.addAll(DataRepository.getInstance().getRealWorldApps());
+        allModelObjects.addAll(DataRepository.getInstance().getTools());
+        allModelObjects.addAll(DataRepository.getInstance().getBooks());
+        allModelObjects.addAll(DataRepository.getInstance().getBlogs());
         Collections.shuffle(allModelObjects);
 
         /*
          * For now we do not feature videos, tutorials, people, or blogs.
          */
-//        allModelObjects.addAll(DataRepository2.getInstance().getVideos());
-//        allModelObjects.addAll(DataRepository2.getInstance().getTutorials());
-//        allModelObjects.addAll(DataRepository2.getInstance().getPeople());
-//        allModelObjects.addAll(DataRepository2.getInstance().getBlogs());
+//        allModelObjects.addAll(DataRepository.getInstance().getVideos());
+//        allModelObjects.addAll(DataRepository.getInstance().getTutorials());
+//        allModelObjects.addAll(DataRepository.getInstance().getPeople());
+//        allModelObjects.addAll(DataRepository.getInstance().getBlogs());
 
 
         allModelObjects

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/LearnPaginationBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/LearnPaginationBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral.data.model.LearnJavaFX;
 import com.dlsc.jfxcentral.data.model.LearnMobile;
@@ -28,11 +28,11 @@ public class LearnPaginationBox extends HBox {
 
         List<? extends Learn> learnList;
         if (learn instanceof LearnJavaFX) {
-            learnList = DataRepository2.getInstance().getLearnJavaFX();
+            learnList = DataRepository.getInstance().getLearnJavaFX();
         } else if (learn instanceof LearnMobile) {
-            learnList = DataRepository2.getInstance().getLearnMobile();
+            learnList = DataRepository.getInstance().getLearnMobile();
         } else {
-            learnList = DataRepository2.getInstance().getLearnRaspberryPi();
+            learnList = DataRepository.getInstance().getLearnRaspberryPi();
         }
 
         Button previousButton = new Button();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/LibraryPreviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/LibraryPreviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Image;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -39,7 +39,7 @@ public class LibraryPreviewBox extends PaneBase {
     public LibraryPreviewBox(Library library) {
         this.library = Objects.requireNonNull(library);
         getStyleClass().add("library-preview-box");
-        setLibraryInfo(DataRepository2.getInstance().getLibraryInfo(library));
+        setLibraryInfo(DataRepository.getInstance().getLibraryInfo(library));
         layoutBySize();
     }
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/LinksOfTheWeekView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/LinksOfTheWeekView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.NodeUtil;
@@ -103,7 +103,7 @@ public class LinksOfTheWeekView extends PaneBase {
                 dateLabel.setText(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(week.getCreatedOn()));
 
                 CustomMarkdownView markdownView = new CustomMarkdownView();
-                markdownView.setMdString(DataRepository2.getInstance().getLinksOfTheWeekReadMe(week));
+                markdownView.setMdString(DataRepository.getInstance().getLinksOfTheWeekReadMe(week));
                 markdownView.setPrefHeight(markdownView.getWidth());
 
                 VBox weekBox = new VBox(markdownView);
@@ -127,7 +127,7 @@ public class LinksOfTheWeekView extends PaneBase {
     }
 
     protected List<LinksOfTheWeek> getSortedList() {
-        return DataRepository2.getInstance().getLinksOfTheWeek()
+        return DataRepository.getInstance().getLinksOfTheWeek()
                 .stream()
                 .sorted(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed())
                 .toList();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/MemberCellView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/MemberCellView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Member;
 import javafx.geometry.Pos;
@@ -28,7 +28,7 @@ public class MemberCellView extends PaneBase {
         jobTitleLabel.setText(member.getJobTitle());
 
         descriptionMd = new CustomMarkdownView();
-        descriptionMd.setMdString(DataRepository2.getInstance().getMemberReadMe(member));
+        descriptionMd.setMdString(DataRepository.getInstance().getMemberReadMe(member));
 
         socialLinksView = new SocialLinksView(true);
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
 import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
@@ -203,7 +203,7 @@ public class PacksIconsView extends PaneBase {
         packGridView.managedProperty().bind(visibleProperty());
 
         // packs data
-        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(DataRepository2.getInstance().getIkonliPacks());
+        ObservableList<IkonliPack> packs = FXCollections.observableArrayList(DataRepository.getInstance().getIkonliPacks());
         FilteredList<IkonliPack> filteredPacks = new FilteredList<>(packs);
         filteredPacks.predicateProperty().bind(Bindings.createObjectBinding(() -> {
             String text = searchText.get().trim();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/TopMenuBar.java
@@ -2,7 +2,7 @@ package com.dlsc.jfxcentral2.components;
 
 import com.dlsc.gemsfx.SearchField;
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -146,7 +146,7 @@ public class TopMenuBar extends PaneBase {
     }
 
     public List<ModelObject> search(String pattern) {
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
 
         List<ModelObject> results = new ArrayList<>();
         search(repository.getBooks(), pattern, results);

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/WeekLinksLiteView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/WeekLinksLiteView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.components;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
@@ -49,7 +49,7 @@ public class WeekLinksLiteView extends PaneBase {
             }
             DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL);
             String date = String.format("## Posted on %s%n%n", formatter.format(linksOfTheWeek.getCreatedOn()));
-            String mdStr = DataRepository2.getInstance().getLinksOfTheWeekReadMe(linksOfTheWeek);
+            String mdStr = DataRepository.getInstance().getLinksOfTheWeekReadMe(linksOfTheWeek);
             return date + mdStr;
         }, linksOfTheWeekProperty()));
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/detailsbox/DetailsBoxBase.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/detailsbox/DetailsBoxBase.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.components.detailsbox;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -171,9 +171,9 @@ public abstract class DetailsBoxBase<T extends ModelObject> extends PaneBase {
 
         // some model objects have a more suitable description (currently) in their readme files
         if (model instanceof Download download) {
-            return DataRepository2.getInstance().getDownloadReadMe(download);
+            return DataRepository.getInstance().getDownloadReadMe(download);
         } else if (model instanceof Person person) {
-            return DataRepository2.getInstance().getPersonReadMe(person);
+            return DataRepository.getInstance().getPersonReadMe(person);
         }
 
         return "(Missing description)";

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/detailsbox/LibraryCoordinatesBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/detailsbox/LibraryCoordinatesBox.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.components.detailsbox;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Coordinates;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 import com.dlsc.jfxcentral2.components.Header;
@@ -48,7 +48,7 @@ public class LibraryCoordinatesBox extends PaneBase implements NameProvider {
         StringProperty versionProperty = new SimpleStringProperty(this, "version");
 
         if (isAvailable) {
-            FXFuture.runBackground(() -> DataRepository2.getInstance().getArtifactVersion(coordinates)).map(property -> {
+            FXFuture.runBackground(() -> DataRepository.getInstance().getArtifactVersion(coordinates)).map(property -> {
                 versionProperty.bind(property);
                 return null;
             });

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.filters;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import org.apache.commons.lang3.StringUtils;
 
@@ -49,7 +49,7 @@ public class DocumentationFilterView extends SimpleSearchFilterView<Documentatio
     private List<FilterItem<Documentation>> getVideoFilterItems(
             Function<Documentation, String> attrGetter,
             BiPredicate<Documentation, String> predicate) {
-        List<Documentation> appList = DataRepository2.getInstance().getDocumentation();
+        List<Documentation> appList = DataRepository.getInstance().getDocumentation();
 
         ArrayList<FilterItem<Documentation>> filterItems = new ArrayList<>(appList.stream()
                 .flatMap(app -> Optional.ofNullable(attrGetter.apply(app)).stream()

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/LearnFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/LearnFilterView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.filters;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral.data.model.LearnJavaFX;
 import com.dlsc.jfxcentral.data.model.LearnMobile;
@@ -24,13 +24,13 @@ public class LearnFilterView extends SimpleModelObjectSearchFilterView<Learn> {
         setSortGroup(new SortGroup<>("ORDER", List.of(
                 new SortItem<>("Natural Order", Comparator.comparing((Learn modelObject) -> {
                     if (modelObject instanceof LearnJavaFX fxmodel) {
-                        List<LearnJavaFX> fxList = DataRepository2.getInstance().getLearnJavaFX();
+                        List<LearnJavaFX> fxList = DataRepository.getInstance().getLearnJavaFX();
                         return fxList.indexOf(fxmodel);
                     } else if (modelObject instanceof LearnMobile mobile) {
-                        List<LearnMobile> mobileList = DataRepository2.getInstance().getLearnMobile();
+                        List<LearnMobile> mobileList = DataRepository.getInstance().getLearnMobile();
                         return mobileList.indexOf(mobile);
                     } else if (modelObject instanceof LearnRaspberryPi pi) {
-                        List<LearnRaspberryPi> piList = DataRepository2.getInstance().getLearnRaspberryPi();
+                        List<LearnRaspberryPi> piList = DataRepository.getInstance().getLearnRaspberryPi();
                         return piList.indexOf(pi);
                     }
                     return 0;

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/ShowcaseFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/ShowcaseFilterView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.filters;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
 import org.apache.commons.lang3.StringUtils;
 
@@ -32,7 +32,7 @@ public class ShowcaseFilterView extends SimpleModelObjectSearchFilterView<RealWo
     }
 
     private List<FilterItem<RealWorldApp>> getDomainFilterItems() {
-        List<RealWorldApp> appList = DataRepository2.getInstance().getRealWorldApps();
+        List<RealWorldApp> appList = DataRepository.getInstance().getRealWorldApps();
 
         ArrayList<FilterItem<RealWorldApp>> filterItems = new ArrayList<>(appList.stream()
                 .flatMap(app -> Optional.ofNullable(app.getDomain()).stream()

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/VideosFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/VideosFilterView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.filters;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Video;
 import org.apache.commons.lang3.StringUtils;
 
@@ -57,7 +57,7 @@ public class VideosFilterView extends SimpleModelObjectSearchFilterView<Video> {
     private List<FilterItem<Video>> getVideoFilterItems(
             Function<Video, String> attrGetter,
             BiPredicate<Video, String> predicate) {
-        List<Video> appList = DataRepository2.getInstance().getVideos();
+        List<Video> appList = DataRepository.getInstance().getVideos();
 
         ArrayList<FilterItem<Video>> filterItems = new ArrayList<>(appList.stream()
                 .flatMap(app -> Optional.ofNullable(attrGetter.apply(app)).stream()

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/headers/PersonDetailHeader.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/headers/PersonDetailHeader.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.headers;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral2.components.AvatarView;
@@ -45,7 +45,7 @@ public class PersonDetailHeader extends DetailHeader<Person> {
         FlowPane nameBadgePane = createNameBadgePane(person);
 
         Label descriptionLabel = new Label();
-        descriptionLabel.setText(DataRepository2.getInstance().getPersonReadMe(person));
+        descriptionLabel.setText(DataRepository.getInstance().getPersonReadMe(person));
         descriptionLabel.setWrapText(true);
         descriptionLabel.getStyleClass().add("description");
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/BlogOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/BlogOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Post;
@@ -55,7 +55,7 @@ public class BlogOverviewBox extends OverviewBox<Blog> {
                 return new Task<>() {
                     @Override
                     protected Void call() throws InterruptedException {
-                        List<Post> posts = DataRepository2.getInstance().loadPosts(getModel());
+                        List<Post> posts = DataRepository.getInstance().loadPosts(getModel());
                         Thread.sleep(500);
                         Platform.runLater(() -> {
                             box.getChildren().clear();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/BookOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/BookOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral2.components.CustomImageView;
@@ -21,8 +21,8 @@ public class BookOverviewBox extends OverviewBox<Book> {
     public BookOverviewBox(Book book) {
         super(book);
         getStyleClass().add("book-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "books/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getBookReadMe(book));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "books/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getBookReadMe(book));
     }
 
     @Override

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/CompanyOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/CompanyOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Company;
 
 public class CompanyOverviewBox extends SimpleOverviewBox<Company> {
@@ -8,7 +8,7 @@ public class CompanyOverviewBox extends SimpleOverviewBox<Company> {
     public CompanyOverviewBox(Company company) {
         super(company);
         getStyleClass().add("company-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "companies/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getCompanyReadMe(company));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "companies/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getCompanyReadMe(company));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/DownloadOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/DownloadOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Download;
 
 /*
@@ -11,7 +11,7 @@ public class DownloadOverviewBox extends SimpleOverviewBox<Download> {
     public DownloadOverviewBox(Download download) {
         super(download);
         getStyleClass().add("download-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "downloads/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getDownloadReadMe(download));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "downloads/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getDownloadReadMe(download));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/LearnOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/LearnOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral.data.model.LearnJavaFX;
 import com.dlsc.jfxcentral.data.model.LearnMobile;
@@ -15,14 +15,14 @@ public class LearnOverviewBox extends OverviewBox<Learn> {
         getStyleClass().add("learn-overview-box");
 
         if (learn instanceof LearnJavaFX temp) {
-            setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/javafx/" + learn.getId());
-            setMarkdown(DataRepository2.getInstance().getLearnJavaFXReadMe(temp));
+            setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/javafx/" + learn.getId());
+            setMarkdown(DataRepository.getInstance().getLearnJavaFXReadMe(temp));
         } else if (learn instanceof LearnMobile temp) {
-            setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/mobile/" + learn.getId());
-            setMarkdown(DataRepository2.getInstance().getLearnMobileReadMe(temp));
+            setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/mobile/" + learn.getId());
+            setMarkdown(DataRepository.getInstance().getLearnMobileReadMe(temp));
         } else {
-            setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/raspberrypi/" + learn.getId());
-            setMarkdown(DataRepository2.getInstance().getLearnRaspberryPiReadMe((LearnRaspberryPi) learn));
+            setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/raspberrypi/" + learn.getId());
+            setMarkdown(DataRepository.getInstance().getLearnRaspberryPiReadMe((LearnRaspberryPi) learn));
         }
     }
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/LibraryOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/LibraryOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Library;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 import com.dlsc.jfxcentral2.components.Header;
@@ -28,8 +28,8 @@ public class LibraryOverviewBox extends PaneBase implements NameProvider {
         header.visibleProperty().bind(titleProperty().isNotEmpty().and(iconProperty().isNotNull()));
 
         CustomMarkdownView markdownView = new CustomMarkdownView();
-        markdownView.setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "libraries/" + library.getId());
-        markdownView.setMdString(DataRepository2.getInstance().getLibraryReadMe(library));
+        markdownView.setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "libraries/" + library.getId());
+        markdownView.setMdString(DataRepository.getInstance().getLibraryReadMe(library));
 
         LibraryPreviewBox libraryPreviewBox = new LibraryPreviewBox(library);
         libraryPreviewBox.sizeProperty().bind(sizeProperty());

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/ShowcaseOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/ShowcaseOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
 import com.dlsc.jfxcentral2.utils.OSUtil;
 import javafx.geometry.HPos;
@@ -45,7 +45,7 @@ public class ShowcaseOverviewBox extends OverviewBox<RealWorldApp> {
         FieldGroup createdOnGroup = new FieldGroup("CREATED ON", new String[]{"field-value"});
         createdOnLabel = createdOnGroup.getLabel();
 
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "realworld/" + getModel().getId());
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "realworld/" + getModel().getId());
         fillData();
 
         if (!isSmall()) {
@@ -107,7 +107,7 @@ public class ShowcaseOverviewBox extends OverviewBox<RealWorldApp> {
             if (app.getCreationOrUpdateDate() != null) {
                 createdOnLabel.setText(app.getCreationOrUpdateDate().format(DEFAULT_DATE_FORMATTER));
             }
-            setMarkdown(DataRepository2.getInstance().getRealWorldReadMe(app));
+            setMarkdown(DataRepository.getInstance().getRealWorldReadMe(app));
         } else {
             locationLabel.setText("");
             domainLabel.setText("");

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/TipOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/TipOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tip;
 
 public class TipOverviewBox extends OverviewBox<Tip> {
@@ -8,7 +8,7 @@ public class TipOverviewBox extends OverviewBox<Tip> {
     public TipOverviewBox(Tip tip) {
         super(tip);
         getStyleClass().add("tip-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "tips/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getTipReadMe(tip));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "tips/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getTipReadMe(tip));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/ToolOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/ToolOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tool;
 
 public class ToolOverviewBox extends SimpleOverviewBox<Tool> {
@@ -8,7 +8,7 @@ public class ToolOverviewBox extends SimpleOverviewBox<Tool> {
     public ToolOverviewBox(Tool tool) {
         super(tool);
         getStyleClass().add("tool-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "tools/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getToolReadMe(tool));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "tools/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getToolReadMe(tool));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/TutorialOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/TutorialOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Tutorial;
 
@@ -9,8 +9,8 @@ public class TutorialOverviewBox extends SimpleOverviewBox<Tutorial> {
     public TutorialOverviewBox(Tutorial tutorial) {
         super(tutorial);
         getStyleClass().add("tutorial-overview-box");
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "tutorials/" + getModel().getId());
-        setMarkdown(DataRepository2.getInstance().getTutorialReadMe(tutorial));
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "tutorials/" + getModel().getId());
+        setMarkdown(DataRepository.getInstance().getTutorialReadMe(tutorial));
         imageProperty().bind(ImageManager.getInstance().tutorialImageLargeProperty(tutorial));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/UtilityOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/UtilityOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Utility;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
@@ -104,7 +104,7 @@ public class UtilityOverviewBox extends OverviewBox<Utility> {
     }
 
     private Node readmeView(Utility model) {
-        String readme = DataRepository2.getInstance().getUtilityReadMe(model);
+        String readme = DataRepository.getInstance().getUtilityReadMe(model);
         CustomMarkdownView markdownView = new CustomMarkdownView(readme);
         markdownView.setDisable(!ModelObjectTool.isUtilityCanBeUsed(model));
         return markdownView;

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/VideoOverviewBox.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/overviewbox/VideoOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.overviewbox;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 import com.dlsc.jfxcentral2.utils.VideoViewFactory;
@@ -15,7 +15,7 @@ public class VideoOverviewBox extends SimpleOverviewBox<Video> {
 
         // there is no markdown for videos, but we might add it in the future,
         // so let's specify the base url ... just to be sure
-        setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "videos/" + video.getId());
+        setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "videos/" + video.getId());
     }
 
     @Override

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/LearnTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/LearnTileView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.tiles;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.components.AvatarView;
@@ -33,7 +33,7 @@ public class LearnTileView extends SimpleTileView<Learn> {
         HBox developmentStatusBox = getLinkedObjectBox();
         developmentStatusBox.getChildren().clear();
         Learn learn = getData();
-        learn.getPersonIds().forEach(id -> DataRepository2.getInstance().getPersonById(id)
+        learn.getPersonIds().forEach(id -> DataRepository.getInstance().getPersonById(id)
                 .ifPresent(person -> {
                     AvatarView avatarView = new AvatarView();
                     avatarView.setTooltip(new Tooltip(person.getName()));

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/PersonTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/PersonTileView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.tiles;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral2.components.SocialLinksView;
@@ -34,7 +34,7 @@ public class PersonTileView extends SimpleTileView<Person> {
         imageProperty().bind(ImageManager.getInstance().personImageProperty(person));
 
         setTitle(person.getName());
-        setDescription(DataRepository2.getInstance().getPersonReadMe(person));
+        setDescription(DataRepository.getInstance().getPersonReadMe(person));
 
         //add badges
         badgeBox.getChildren().clear();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/tiles/SimpleTileView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.components.tiles;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral.data.model.Download;
@@ -174,7 +174,7 @@ public class SimpleTileView<T extends ModelObject> extends TileViewBase<T> {
             return;
         }
 
-        DataRepository2 dataRepository = DataRepository2.getInstance();
+        DataRepository dataRepository = DataRepository.getInstance();
         List<LinkedObjectBadge> linkedObjectBadge = List.of(
                 new LinkedObjectBadge("Books", IkonUtil.getModelIkon(Book.class), dataRepository.getLinkedObjects(data, Book.class).size()),
                 new LinkedObjectBadge("Apps", IkonUtil.getModelIkon(RealWorldApp.class), dataRepository.getLinkedObjects(data, RealWorldApp.class).size()),

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/topcontent/TopContentContainerView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/topcontent/TopContentContainerView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.components.topcontent;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -80,14 +80,14 @@ public class TopContentContainerView extends PaneBase {
                 return new Task<>() {
                     @Override
                     protected Void call() throws Exception {
-                        List<Tool> tools = DataRepository2.getInstance().getTools();
-                        List<Library> libraries = DataRepository2.getInstance().getLibraries();
-                        List<Blog> blogs = DataRepository2.getInstance().getBlogs();
-                        List<Video> videos = DataRepository2.getInstance().getVideos();
-                        List<Download> downloads = DataRepository2.getInstance().getDownloads();
-                        List<Book> books = DataRepository2.getInstance().getBooks();
-                        List<Company> companies = DataRepository2.getInstance().getCompanies();
-                        List<Tip> tips = DataRepository2.getInstance().getTips();
+                        List<Tool> tools = DataRepository.getInstance().getTools();
+                        List<Library> libraries = DataRepository.getInstance().getLibraries();
+                        List<Blog> blogs = DataRepository.getInstance().getBlogs();
+                        List<Video> videos = DataRepository.getInstance().getVideos();
+                        List<Download> downloads = DataRepository.getInstance().getDownloads();
+                        List<Book> books = DataRepository.getInstance().getBooks();
+                        List<Company> companies = DataRepository.getInstance().getCompanies();
+                        List<Tip> tips = DataRepository.getInstance().getTips();
                         //Display the interface, Pause for 0.5 seconds, then fill the data
                         Thread.sleep(500);
                         Platform.runLater(() -> {

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.utils;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Dependency;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.model.IkonData;
@@ -36,7 +36,7 @@ public class IkonliPackUtil {
                 ikonDataSet.add(IkonData.of(provider));
             }
         }
-        List<IkonliPack> ikonliPacks = DataRepository2.getInstance().getIkonliPacks();
+        List<IkonliPack> ikonliPacks = DataRepository.getInstance().getIkonliPacks();
 
         ikonDataSet.forEach(data -> {
             for (IkonliPack pack : ikonliPacks) {

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/QuickLinksGenerator.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/QuickLinksGenerator.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.utils;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -163,7 +163,7 @@ public class QuickLinksGenerator {
     }
 
     private static List<ModelObject> createShuffledSublist(int size) {
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
 
         List<ModelObject> allModelObjects = new ArrayList<>();
         allModelObjects.addAll(repository.getTips());
@@ -222,7 +222,7 @@ public class QuickLinksGenerator {
     }
 
     private static List<ModelObject> findRecentItems() {
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
 
         List<ModelObject> result = new ArrayList<>();
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LearnListCell.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LearnListCell.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.components.AvatarView;
@@ -43,7 +43,7 @@ public class LearnListCell extends ListCell<Learn> {
             setGraphic(null);
         } else {
             titleLabel.setText(item.getName());
-            item.getPersonIds().forEach(id -> DataRepository2.getInstance().getPersonById(id)
+            item.getPersonIds().forEach(id -> DataRepository.getInstance().getPersonById(id)
                     .ifPresent(person -> {
                         AvatarView avatarView = new AvatarView();
                         avatarView.setTooltip(new Tooltip(person.getName()));

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LearnPagination.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LearnPagination.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral.data.model.LearnJavaFX;
@@ -45,7 +45,7 @@ public class LearnPagination<T extends Learn> extends MobilePagination<T> {
         itemProperty().addListener((obs, oldItem, newItem) -> {
             // update author box
             authorBox.getChildren().clear();
-            newItem.getPersonIds().forEach(id -> DataRepository2.getInstance().getPersonById(id)
+            newItem.getPersonIds().forEach(id -> DataRepository.getInstance().getPersonById(id)
                     .ifPresent(person -> {
                         AvatarView avatarView = new AvatarView();
                         avatarView.setTooltip(new Tooltip(person.getName()));
@@ -65,11 +65,11 @@ public class LearnPagination<T extends Learn> extends MobilePagination<T> {
             }
 
             if (currentItem instanceof LearnJavaFX data) {
-                return DataRepository2.getInstance().getLearnJavaFXReadMe(data);
+                return DataRepository.getInstance().getLearnJavaFXReadMe(data);
             } else if (currentItem instanceof LearnMobile data) {
-                return DataRepository2.getInstance().getLearnMobileReadMe(data);
+                return DataRepository.getInstance().getLearnMobileReadMe(data);
             } else if (currentItem instanceof LearnRaspberryPi data) {
-                return DataRepository2.getInstance().getLearnRaspberryPiReadMe(data);
+                return DataRepository.getInstance().getLearnRaspberryPiReadMe(data);
             }
             return "";
         }, itemProperty(), baseURLProperty()));

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LinkedObjectsBox.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LinkedObjectsBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Company;
@@ -135,7 +135,7 @@ public class LinkedObjectsBox<T extends ModelObject> extends VBox {
     }
 
     private <M extends ModelObject> List<M> getLinkedObjects(T t, Class<M> type) {
-        return DataRepository2.getInstance().getLinkedObjects(t, type);
+        return DataRepository.getInstance().getLinkedObjects(t, type);
     }
 
     // size

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LotwPagination.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/LotwPagination.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 
@@ -21,7 +21,7 @@ public class LotwPagination extends MobilePagination<LinksOfTheWeek> {
             if (lotw == null) {
                 return "";
             }
-            return DataRepository2.getInstance().getLinksOfTheWeekReadMe(lotw);
+            return DataRepository.getInstance().getLinksOfTheWeekReadMe(lotw);
         }, itemProperty()));
 
         scrollPane.setContent(markdownView);

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileBlogOverviewBox.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileBlogOverviewBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Post;
 import com.dlsc.jfxcentral2.components.Header;
@@ -72,7 +72,7 @@ public class MobileBlogOverviewBox extends VBox {
                 return new Task<>() {
                     @Override
                     protected Void call() throws InterruptedException {
-                        List<Post> posts = DataRepository2.getInstance().loadPosts(blog);
+                        List<Post> posts = DataRepository.getInstance().loadPosts(blog);
                         posts.sort((o1, o2) -> o2.getSyndEntry().getPublishedDate().compareTo(o1.getSyndEntry().getPublishedDate()));
                         Thread.sleep(500);
                         Platform.runLater(() -> {

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobilePersonDetailView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobilePersonDetailView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral2.components.AvatarView;
@@ -88,7 +88,7 @@ public class MobilePersonDetailView extends VBox {
 
         // reset the text
         nameLabel.setText(person.getName());
-        descriptionLabel.setText(DataRepository2.getInstance().getPersonReadMe(person));
+        descriptionLabel.setText(DataRepository.getInstance().getPersonReadMe(person));
 
         // reset the boxes
         updateBadge(person);

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileSearchView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/components/MobileSearchView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.components;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.components.SearchResultCell;
 import com.dlsc.jfxcentral2.components.SizeSupport;
@@ -74,7 +74,7 @@ public class MobileSearchView extends StackPane {
     }
 
     private void addSuggestionsToList() {
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
         repository.getPeople().forEach(person -> searchSuggestions.add(person.getName()));
     }
 
@@ -165,7 +165,7 @@ public class MobileSearchView extends StackPane {
     }
 
     public void addModelsToCollection() {
-        DataRepository2 repository = DataRepository2.getInstance();
+        DataRepository repository = DataRepository.getInstance();
         totalResources.addAll(repository.getBooks());
         totalResources.addAll(repository.getBlogs());
         totalResources.addAll(repository.getCompanies());

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/home/CategoryPreviewView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/home/CategoryPreviewView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.home;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
@@ -523,7 +523,7 @@ public class CategoryPreviewView extends VBox {
         for (Person person : people) {
             CategoryPreviewView.CategoryItem item = new CategoryPreviewView.CategoryItem(
                     person.getName(),
-                    DataRepository2.getInstance().getPersonReadMe(person),
+                    DataRepository.getInstance().getPersonReadMe(person),
                     ImageManager.getInstance().personImageProperty(person),
                     ModelObjectTool.getModelLink(person)
             );

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/home/WeekLinksView.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/home/WeekLinksView.java
@@ -1,7 +1,7 @@
 package com.dlsc.jfxcentral2.mobile.home;
 
 import com.dlsc.gemsfx.Spacer;
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.CustomMarkdownView;
 import com.dlsc.jfxcentral2.components.SizeSupport;
@@ -61,7 +61,7 @@ public class WeekLinksView extends VBox {
             }
             DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL);
             String date = String.format("## Posted on %s%n%n", formatter.format(linksOfTheWeek.getCreatedOn()));
-            String mdStr = DataRepository2.getInstance().getLinksOfTheWeekReadMe(linksOfTheWeek);
+            String mdStr = DataRepository.getInstance().getLinksOfTheWeekReadMe(linksOfTheWeek);
             return date + mdStr;
         }, linksOfTheWeekProperty()));
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileHomePage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral.data.model.Library;
@@ -110,31 +110,31 @@ public class MobileHomePage extends MobilePageBase {
 
         LearnCategoryBox learnCategoryBox = new LearnCategoryBox();
 
-        List<RealWorldApp> randomApps = getRandomSample(DataRepository2.getInstance().getRealWorldApps(), 3);
+        List<RealWorldApp> randomApps = getRandomSample(DataRepository.getInstance().getRealWorldApps(), 3);
         CategoryPreviewView showCasePreviewView = CategoryPreviewView.createShowCasePreviewView(randomApps, PagePath.SHOWCASES);
         showCasePreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Tip> randomTips = getRandomSample(DataRepository2.getInstance().getTips(), 2);
+        List<Tip> randomTips = getRandomSample(DataRepository.getInstance().getTips(), 2);
         CategoryPreviewView tipsPreviewView = CategoryPreviewView.createTipsPreviewView(randomTips, PagePath.TIPS);
         tipsPreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Person> randomPeople = getRandomSample(DataRepository2.getInstance().getPeople(), 3);
+        List<Person> randomPeople = getRandomSample(DataRepository.getInstance().getPeople(), 3);
         CategoryPreviewView peoplePreviewView = CategoryPreviewView.createPeoplePreviewView(randomPeople, PagePath.PEOPLE);
         peoplePreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Book> randomBooks = getRandomSample(DataRepository2.getInstance().getBooks(), 3);
+        List<Book> randomBooks = getRandomSample(DataRepository.getInstance().getBooks(), 3);
         CategoryPreviewView booksPreviewView = CategoryPreviewView.createBooksPreviewView(randomBooks, PagePath.BOOKS);
         booksPreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Library> randomLibraries = getRandomSample(DataRepository2.getInstance().getLibraries(), 3);
+        List<Library> randomLibraries = getRandomSample(DataRepository.getInstance().getLibraries(), 3);
         CategoryPreviewView libraryPreviewView = CategoryPreviewView.createLibraryPreviewView(randomLibraries, PagePath.LIBRARIES);
         libraryPreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Video> randomVideos = getRandomSample(DataRepository2.getInstance().getVideos(), 3);
+        List<Video> randomVideos = getRandomSample(DataRepository.getInstance().getVideos(), 3);
         CategoryPreviewView videoPreviewView = CategoryPreviewView.createVideosPreviewView(randomVideos, PagePath.VIDEOS);
         videoPreviewView.sizeProperty().bind(sizeProperty());
 
-        List<Blog> randomBlogs = getRandomSample(DataRepository2.getInstance().getBlogs(), 2);
+        List<Blog> randomBlogs = getRandomSample(DataRepository.getInstance().getBlogs(), 2);
         CategoryPreviewView blogPreviewView = CategoryPreviewView.createBlogPreviewView(randomBlogs, PagePath.BLOGS);
         blogPreviewView.sizeProperty().bind(sizeProperty());
 

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileLinksOfTheWeekPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/MobileLinksOfTheWeekPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.MobilePageBase;
 import com.dlsc.jfxcentral2.mobile.components.LotwPagination;
@@ -34,7 +34,7 @@ public class MobileLinksOfTheWeekPage extends MobilePageBase {
         header.setIcon(IkonUtil.getModelIkon(LinksOfTheWeek.class));
 
         // sort by date
-        ArrayList<LinksOfTheWeek> sortedLinks = new ArrayList<>(DataRepository2.getInstance().getLinksOfTheWeek());
+        ArrayList<LinksOfTheWeek> sortedLinks = new ArrayList<>(DataRepository.getInstance().getLinksOfTheWeek());
         sortedLinks.sort(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed());
 
         LotwPagination pagination = new LotwPagination();

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileBlogsCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileBlogsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Blog;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -54,6 +54,6 @@ public class MobileBlogsCategoryPage extends MobileCategoryPageBase<Blog> {
 
     @Override
     protected ObservableList<Blog> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getBlogs());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getBlogs());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileBooksCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileBooksCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Book;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
 import com.dlsc.jfxcentral2.model.Size;
@@ -48,6 +48,6 @@ public class MobileBooksCategoryPage extends MobileCategoryPageBase<Book> {
 
     @Override
     protected ObservableList<Book> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getBooks());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getBooks());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileCompaniesCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileCompaniesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Company;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileCompaniesCategoryPage extends MobileCategoryPageBase<Company>
 
     @Override
     protected ObservableList<Company> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getCompanies());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getCompanies());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileDocPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileDocPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Documentation;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -54,6 +54,6 @@ public class MobileDocPage extends MobileCategoryPageBase<Documentation> {
 
     @Override
     protected ObservableList<Documentation> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getDocumentation());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getDocumentation());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnJavaFXCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnJavaFXCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -20,7 +20,7 @@ public class MobileLearnJavaFXCategoryPage extends MobileLearnCategoryPage {
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnJavaFX());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnJavaFX());
     }
 
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnMobileCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnMobileCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -20,6 +20,6 @@ public class MobileLearnMobileCategoryPage extends MobileLearnCategoryPage {
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnMobile());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnMobile());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnRaspberryPiCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLearnRaspberryPiCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
 import javafx.beans.property.ObjectProperty;
@@ -20,6 +20,6 @@ public class MobileLearnRaspberryPiCategoryPage extends MobileLearnCategoryPage 
 
     @Override
     protected ObservableList<Learn> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLearnRaspberryPi());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLearnRaspberryPi());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLibrariesCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileLibrariesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Library;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileLibrariesCategoryPage extends MobileCategoryPageBase<Library>
 
     @Override
     protected ObservableList<Library> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getLibraries());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLibraries());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobilePeopleCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobilePeopleCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -35,7 +35,7 @@ public class MobilePeopleCategoryPage extends MobileCategoryPageBase<Person> {
 
             @Override
             protected String getSummary(Person person) {
-                return DataRepository2.getInstance().getPersonReadMe(person);
+                return DataRepository.getInstance().getPersonReadMe(person);
             }
         };
     }
@@ -44,7 +44,7 @@ public class MobilePeopleCategoryPage extends MobileCategoryPageBase<Person> {
     protected Callback<String, Predicate<Person>> getFilter() {
         return text -> person -> StringUtils.isBlank(text)
                 || StringUtils.containsIgnoreCase(person.getName(), text)
-                || StringUtils.containsIgnoreCase(DataRepository2.getInstance().getPersonReadMe(person), text)
+                || StringUtils.containsIgnoreCase(DataRepository.getInstance().getPersonReadMe(person), text)
                 || StringUtils.containsIgnoreCase(person.getDescription(), text);
     }
 
@@ -65,6 +65,6 @@ public class MobilePeopleCategoryPage extends MobileCategoryPageBase<Person> {
 
     @Override
     protected ObservableList<Person> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getPeople());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getPeople());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileShowcasesCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileShowcasesCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
 import com.dlsc.jfxcentral2.model.Size;
@@ -48,7 +48,7 @@ public class MobileShowcasesCategoryPage extends MobileCategoryPageBase<RealWorl
 
     @Override
     protected ObservableList<RealWorldApp> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getRealWorldApps());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getRealWorldApps());
     }
 
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileTipCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileTipCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Tip;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileTipCategoryPage extends MobileCategoryPageBase<Tip> {
 
     @Override
     protected ObservableList<Tip> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTips());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTips());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileToolsCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileToolsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Tool;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileToolsCategoryPage extends MobileCategoryPageBase<Tool> {
 
     @Override
     protected ObservableList<Tool> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTools());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTools());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileTutorialsCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileTutorialsCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Tutorial;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileTutorialsCategoryPage extends MobileCategoryPageBase<Tutorial
 
     @Override
     protected ObservableList<Tutorial> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getTutorials());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getTutorials());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileVideosCategoryPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/category/MobileVideosCategoryPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.category;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Video;
 import com.dlsc.jfxcentral2.mobile.components.ModelListCell;
@@ -48,6 +48,6 @@ public class MobileVideosCategoryPage extends MobileCategoryPageBase<Video> {
 
     @Override
     protected ObservableList<Video> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository2.getInstance().getVideos());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getVideos());
     }
 }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileDetailsPageBase.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileDetailsPageBase.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.details;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral2.components.MobilePageBase;
 import com.dlsc.jfxcentral2.model.Size;
@@ -18,7 +18,7 @@ public abstract class MobileDetailsPageBase<T extends ModelObject> extends Mobil
         this.clazz = clazz;
 
         sizeProperty().bind(size);
-        setItem(DataRepository2.getInstance().getByID(clazz, itemId));
+        setItem(DataRepository.getInstance().getByID(clazz, itemId));
         getChildren().addAll(content());
         getStyleClass().add("mobile-details-page");
     }

--- a/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLearnDetailsPage.java
+++ b/mobile/src/main/java/com/dlsc/jfxcentral2/mobile/pages/details/MobileLearnDetailsPage.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.mobile.pages.details;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral.data.model.LearnJavaFX;
 import com.dlsc.jfxcentral.data.model.LearnMobile;
@@ -32,16 +32,16 @@ public class MobileLearnDetailsPage extends MobileDetailsPageBase<Learn> {
         // content
         LearnPagination<Learn> detailsView = new LearnPagination<>();
         if (learn instanceof LearnJavaFX) {
-            detailsView.setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/javafx/" + learn.getId());
-            List<LearnJavaFX> learnJavaFX = DataRepository2.getInstance().getLearnJavaFX();
+            detailsView.setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/javafx/" + learn.getId());
+            List<LearnJavaFX> learnJavaFX = DataRepository.getInstance().getLearnJavaFX();
             detailsView.getItems().setAll(learnJavaFX);
         } else if (learn instanceof LearnMobile) {
-            detailsView.setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/mobile/" + learn.getId());
-            List<LearnMobile> learnMobile = DataRepository2.getInstance().getLearnMobile();
+            detailsView.setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/mobile/" + learn.getId());
+            List<LearnMobile> learnMobile = DataRepository.getInstance().getLearnMobile();
             detailsView.getItems().setAll(learnMobile);
         } else if (learn instanceof LearnRaspberryPi) {
-            List<LearnRaspberryPi> learnRaspberryPi = DataRepository2.getInstance().getLearnRaspberryPi();
-            detailsView.setBaseURL(DataRepository2.getInstance().getRepositoryDirectoryURL() + "learn/raspberrypi/" + learn.getId());
+            List<LearnRaspberryPi> learnRaspberryPi = DataRepository.getInstance().getLearnRaspberryPi();
+            detailsView.setBaseURL(DataRepository.getInstance().getRepositoryDirectoryURL() + "learn/raspberrypi/" + learn.getId());
             detailsView.getItems().setAll(learnRaspberryPi);
         }
         detailsView.setSelectedItem(learn);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/HelloTeamView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/HelloTeamView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.TeamView;
 import javafx.scene.Node;
@@ -15,7 +15,7 @@ public class HelloTeamView extends JFXCentralSampleBase {
     protected Region createControl() {
         teamView = new TeamView();
 
-        teamView.getMembers().setAll(DataRepository2.getInstance().getMembers());
+        teamView.getMembers().setAll(DataRepository.getInstance().getMembers());
         return new ScrollPane(teamView);
     }
 

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloDownloadsBox.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloDownloadsBox.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Download;
 import com.dlsc.jfxcentral2.components.DownloadsBox;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
@@ -15,7 +15,7 @@ public class HelloDownloadsBox extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        Download download = DataRepository2.getInstance().getDownloads().get(0);
+        Download download = DataRepository.getInstance().getDownloads().get(0);
         downloadsBox = new DownloadsBox(download);
         return new StackPane(downloadsBox);
     }

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonGridView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonGridView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
 import com.dlsc.jfxcentral2.demo.JFXCentralSampleBase;
@@ -19,7 +19,7 @@ public class HelloIkonGridView extends JFXCentralSampleBase {
     @Override
     protected Region createControl() {
         ikonGridView = new IkonGridView();
-        List<Ikon> ikonList = IkonliPackUtil.getInstance().getIkonList(DataRepository2.getInstance().getIkonliPacks().get(0));
+        List<Ikon> ikonList = IkonliPackUtil.getInstance().getIkonList(DataRepository.getInstance().getIkonliPacks().get(0));
         ikonGridView.getItems().addAll(ikonList);
         return new ScrollPane(ikonGridView);
     }

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonPackTileView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloIkonPackTileView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
@@ -15,7 +15,7 @@ public class HelloIkonPackTileView extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        IkonliPack ikonPackModel = DataRepository2.getInstance().getIkonliPacks().get(0);
+        IkonliPack ikonPackModel = DataRepository.getInstance().getIkonliPacks().get(0);
         ikonPackModel.setDescription("Some description");
 
         ikonPackModelTileView = new IkonliPackTileView(ikonPackModel);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloLibraryTileView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloLibraryTileView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Library;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.tiles.LibraryTileView;
@@ -15,7 +15,7 @@ public class HelloLibraryTileView extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        Library library = DataRepository2.getInstance().getLibraries().stream().filter(l -> l.getId().equalsIgnoreCase("FXGL")).findFirst().get();
+        Library library = DataRepository.getInstance().getLibraries().stream().filter(l -> l.getId().equalsIgnoreCase("FXGL")).findFirst().get();
 
         libraryTileView = new LibraryTileView(library);
         return new ScrollPane(libraryTileView);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloPackGridView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloPackGridView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.IkonliPack;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
@@ -19,7 +19,7 @@ public class HelloPackGridView extends JFXCentralSampleBase {
 
         gridView = new ModelGridView<>();
         gridView.setTileViewProvider(IkonliPackTileView::new);
-        gridView.getItems().setAll(DataRepository2.getInstance().getIkonliPacks());
+        gridView.getItems().setAll(DataRepository.getInstance().getIkonliPacks());
 
         return new ScrollPane(gridView);
     }

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloTopContentView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloTopContentView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Tool;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.components.topcontent.TopContentView;
@@ -19,7 +19,7 @@ public class HelloTopContentView extends JFXCentralSampleBase {
 
         topContentView = new TopContentView<>();
 
-        topContentView.getItems().setAll(DataRepository2.getInstance().getTools());
+        topContentView.getItems().setAll(DataRepository.getInstance().getTools());
 
         return new ScrollPane(topContentView);
     }

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/devtools/HelloSVGPathExtractorView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/devtools/HelloSVGPathExtractorView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.devtools;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Utility;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
 import com.dlsc.jfxcentral2.demo.JFXCentralSampleBase;
@@ -17,7 +17,7 @@ public class HelloSVGPathExtractorView extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        Optional<Utility> path = DataRepository2.getInstance().getUtilities().stream().filter(t -> t.getId().contains("path")).findFirst();
+        Optional<Utility> path = DataRepository.getInstance().getUtilities().stream().filter(t -> t.getId().contains("path")).findFirst();
         view = new SVGPathExtractorView(path.get());
         ScrollPane scrollPane = new ScrollPane(view);
         scrollPane.setPrefWidth(1600);

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/mobile/HelloCategoryPreviewView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/mobile/HelloCategoryPreviewView.java
@@ -1,6 +1,6 @@
 package com.dlsc.jfxcentral2.demo.mobile;
 
-import com.dlsc.jfxcentral.data.DataRepository2;
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.ImageManager;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
@@ -45,7 +45,7 @@ public class HelloCategoryPreviewView extends JFXCentralSampleBase {
         view.setTitle("Real World Apps");
         view.setShowAllUrl(PagePath.SHOWCASES);
         List<CategoryPreviewView.CategoryItem> items = new ArrayList<>();
-        List<RealWorldApp> apps = DataRepository2.getInstance().getRealWorldApps();
+        List<RealWorldApp> apps = DataRepository.getInstance().getRealWorldApps();
         for (int i = 0; i < 2; i++) {
             RealWorldApp app = apps.get(random.nextInt(apps.size()));
             CategoryPreviewView.CategoryItem item = new CategoryPreviewView.CategoryItem(
@@ -71,13 +71,13 @@ public class HelloCategoryPreviewView extends JFXCentralSampleBase {
         view.setTitle("People");
         view.setShowAllUrl(PagePath.PEOPLE);
         List<CategoryPreviewView.CategoryItem> items = new ArrayList<>();
-        List<Person> people = DataRepository2.getInstance().getPeople();
+        List<Person> people = DataRepository.getInstance().getPeople();
 
         for (int i = 0; i < 2; i++) {
             Person person = people.get(random.nextInt(people.size()));
             CategoryPreviewView.CategoryItem item = new CategoryPreviewView.CategoryItem(
                     person.getName(),
-                    DataRepository2.getInstance().getPersonReadMe(person),
+                    DataRepository.getInstance().getPersonReadMe(person),
                     null,
                     ImageManager.getInstance().personImageProperty(person),
                     ModelObjectTool.getModelLink(person),
@@ -98,7 +98,7 @@ public class HelloCategoryPreviewView extends JFXCentralSampleBase {
         view.setTitle("Tips");
         view.setShowAllUrl(PagePath.TIPS);
         List<CategoryPreviewView.CategoryItem> items = new ArrayList<>();
-        List<Tip> tips = DataRepository2.getInstance().getTips();
+        List<Tip> tips = DataRepository.getInstance().getTips();
         for (int i = 0; i < 2; i++) {
             Tip tip = tips.get(random.nextInt(tips.size()));
             CategoryPreviewView.CategoryItem item = new CategoryPreviewView.CategoryItem(


### PR DESCRIPTION
Renamed all instances of DataRepository2 to DataRepository across the project. This change aligns with the recent updates in the `jfxcentral-data` project, where DataRepository2 was deprecated and renamed to DataRepository. This update ensures consistency with the latest project structure and removes references to the now-obsolete DataRepository2.


#### A subtle bug has been observed post-refactor, detailed as follows:

##### Replication Steps:

1. Delete existing .jfxcentralrepo cache file.
2. Run JFXCentral2App (develop).
3. Observe the data loading process and subsequent console error indicating a missing ...people/people.json file. (no such fiel).
4. A IndexOutOfBoundsException in QuickLinksGenerator's checkArrayList method because createShuffledSublist returns an empty list, contrary to expectations.
#####  Possible Cause: 
The bug seems related to the getRepositoryDirectory method in DataRepository (jfxcentral-data). The method’s behavior changes based on whether it is **static** or not:

Static: No bug triggered.
Non-static: Bug appears.