### PR TITLE
Add direct URLs for the links

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -11,6 +11,7 @@ import com.dlsc.jfxcentral.data.model.LearnJavaFX;
 import com.dlsc.jfxcentral.data.model.LearnMobile;
 import com.dlsc.jfxcentral.data.model.LearnRaspberryPi;
 import com.dlsc.jfxcentral.data.model.Library;
+import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral.data.model.ModelObject;
 import com.dlsc.jfxcentral.data.model.Person;
 import com.dlsc.jfxcentral.data.model.RealWorldApp;
@@ -283,7 +284,7 @@ public class JFXCentral2App extends Application {
                 .and(Route.get(PagePath.LEGAL_TERMS, r -> Response.view(new LegalPage(size, LegalPage.Section.TERMS))))
                 .and(Route.get(PagePath.LEGAL_COOKIES, r -> Response.view(new LegalPage(size, LegalPage.Section.COOKIES))))
                 .and(Route.get(PagePath.LEGAL_PRIVACY, r -> Response.view(new LegalPage(size, LegalPage.Section.PRIVACY))))
-                .and(Route.get(PagePath.LINKS, r -> Response.view(new LinksOfTheWeekPage(size))))
+                .and(createLOTWRoute())
                 .and(Route.get(PagePath.TEAM, r -> Response.view(new TeamPage(size))))
                 .and(Route.get(PagePath.OPENJFX, r -> Response.view(new OpenJFXPage(size))))
                 .and(Route.get(PagePath.DOCUMENTATION, r -> Response.view(new DocumentationCategoryPage(size))))
@@ -313,6 +314,31 @@ public class JFXCentral2App extends Application {
         //}
 
         return route;
+    }
+
+    private Route createLOTWRoute() {
+        return request -> {
+            if (request.getPath().startsWith(PagePath.LINKS)) {
+                String pathWithoutLinks = request.getPath().replace(PagePath.LINKS, "");
+                int i = pathWithoutLinks.lastIndexOf("/");
+                if (i < 0) {
+                    return Response.view(new LinksOfTheWeekPage(size));
+                }
+                // request date: e.g. 2024-07-28
+                String formatedDate = pathWithoutLinks.substring(i + 1);
+                if (!formatedDate.matches("\\d{4}-\\d{2}-\\d{2}")) {
+                    return Response.view(new ErrorPage(size, request));
+                }
+
+                // links of week id: e.g. 2024/2024-07/2024-07-28
+                String id = String.format("%s/%s/%s", formatedDate.substring(0, 4), formatedDate.substring(0, 7), formatedDate);
+                if (!DataRepository.getInstance().isValidId(LinksOfTheWeek.class, id)) {
+                    return Response.view(new ErrorPage(size, request));
+                }
+                return Response.view(new LinksOfTheWeekPage(size, id));
+            }
+            return Response.empty();
+        };
     }
 
     private Route createCategoryOrDetailRoute(String path, Class<? extends ModelObject> clazz, Supplier<View> masterResponse, Callback<String, View> detailedResponse) {

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
@@ -34,8 +34,15 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM);
 
+    private String id;
+
     public LinksOfTheWeekPage(ObjectProperty<Size> size) {
         super(size);
+    }
+
+    public LinksOfTheWeekPage(ObjectProperty<Size> size, String id) {
+        super(size);
+        this.id = id;
     }
 
     @Override
@@ -89,6 +96,17 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
                 detailsContentPane.getMenuView().setSelectedIndex(-1);
             }
         });
+
+        if (id != null) {
+            ObservableList<LinksOfTheWeek> linksOfTheWeeks = linksOfTheWeekView.getLinksOfTheWeeks();
+            for (int i = 0; i < linksOfTheWeeks.size(); i++) {
+                LinksOfTheWeek linksOfTheWeek = linksOfTheWeeks.get(i);
+                if (id.equals(linksOfTheWeek.getId())) {
+                    linksOfTheWeekView.goToPage(linksOfTheWeeks.size() - i - 1);
+                    break;
+                }
+            }
+        }
 
         return wrapContent(header, detailsContentPane);
     }

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/LinksOfTheWeekPage.java
@@ -10,6 +10,7 @@ import com.dlsc.jfxcentral2.components.headers.LinksOfTheWeekHeader;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
+import com.dlsc.jfxcentral2.utils.PagePath;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -20,15 +21,17 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.util.Callback;
+import one.jpro.platform.routing.LinkUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.bootstrapicons.BootstrapIcons;
 import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
 
@@ -67,15 +70,22 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
 
     @Override
     public Node content() {
+        // find the LinksOfTheWeek by ID, or use the latest one if ID is null or not found
+        LinksOfTheWeek linksOfTheWeek = Optional.ofNullable(id)
+                .flatMap(searchId -> getCategoryItems().stream()
+                        .filter(lotw -> StringUtils.equals(searchId, lotw.getId()))
+                        .findFirst())
+                .orElse(getCategoryItems().get(0));
 
         // header
         LinksOfTheWeekHeader header = new LinksOfTheWeekHeader();
         header.sizeProperty().bind(sizeProperty());
 
         // links of the week view
-        LinksOfTheWeekView linksOfTheWeekView = new LinksOfTheWeekView();
-        linksOfTheWeekView.getLinksOfTheWeeks().setAll(DataRepository.getInstance().getLinksOfTheWeek());
+        LinksOfTheWeekView linksOfTheWeekView = new LinksOfTheWeekView(linksOfTheWeek);
+        linksOfTheWeekView.getLinksOfTheWeeks().setAll(getCategoryItems());
         linksOfTheWeekView.sizeProperty().bind(sizeProperty());
+        linksOfTheWeekView.setOnGoToLinkOfTheWeek(this::navigateToLinkOfTheWeek);
 
         // this is a category page, but we still need to use the details content pane for layout purposes
         DetailsContentPane detailsContentPane = new DetailsContentPane();
@@ -88,27 +98,20 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
         // this must be the last change to the details content pane, otherwise the menu shows wrong items
         detailsContentPane.getMenuView().getItems().setAll(createMenuItems(linksOfTheWeekView));
 
-        linksOfTheWeekView.selectedIndexProperty().addListener((ob, ov, nv) -> {
-            int size = detailsContentPane.getMenuView().getItems().size();
-            if (nv.intValue() >= 0 && nv.intValue() < size) {
-                detailsContentPane.getMenuView().setSelectedIndex(nv.intValue());
-            } else {
-                detailsContentPane.getMenuView().setSelectedIndex(-1);
-            }
-        });
-
-        if (id != null) {
-            ObservableList<LinksOfTheWeek> linksOfTheWeeks = linksOfTheWeekView.getLinksOfTheWeeks();
-            for (int i = 0; i < linksOfTheWeeks.size(); i++) {
-                LinksOfTheWeek linksOfTheWeek = linksOfTheWeeks.get(i);
-                if (id.equals(linksOfTheWeek.getId())) {
-                    linksOfTheWeekView.goToPage(linksOfTheWeeks.size() - i - 1);
-                    break;
-                }
-            }
-        }
+        // update the selected state of the MenuView
+        selectedMenuItem(detailsContentPane.getMenuView(), linksOfTheWeekView.getSelectedIndex());
+        linksOfTheWeekView.selectedIndexProperty().addListener((ob, ov, nv) -> selectedMenuItem(detailsContentPane.getMenuView(), nv.intValue()));
 
         return wrapContent(header, detailsContentPane);
+    }
+
+    private void selectedMenuItem(MenuView menuView, int selectedIndex) {
+        int size = menuView.getItems().size();
+        if (selectedIndex >= 0 && selectedIndex < size) {
+            menuView.setSelectedIndex(selectedIndex);
+        } else {
+            menuView.setSelectedIndex(-1);
+        }
     }
 
     private HBox createPaginationBox(LinksOfTheWeekView linksOfTheWeekView) {
@@ -140,15 +143,18 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
         paginationBox.getStyleClass().add("pagination-box");
         paginationBox.managedProperty().bind(paginationBox.visibleProperty());
         paginationBox.visibleProperty().bind(Bindings.createBooleanBinding(() ->
-                linksOfTheWeekView.getLinksOfTheWeeks().size() > 1 && sizeProperty().get() == Size.LARGE,
+                        linksOfTheWeekView.getLinksOfTheWeeks().size() > 1 && sizeProperty().get() == Size.LARGE,
                 linksOfTheWeekView.getLinksOfTheWeeks(), sizeProperty())
         );
         return paginationBox;
     }
 
+    /**
+     * Returns "Links of the Week" List, sorted by creation date in descending order.
+     */
     @Override
     protected ObservableList<LinksOfTheWeek> getCategoryItems() {
-        return FXCollections.observableArrayList(DataRepository.getInstance().getLinksOfTheWeek());
+        return FXCollections.observableArrayList(DataRepository.getInstance().getLinksOfTheWeek().stream().sorted(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed()).toList());
     }
 
     @Override
@@ -162,14 +168,17 @@ public class LinksOfTheWeekPage extends CategoryPageBase<LinksOfTheWeek> {
     }
 
     protected List<MenuView.Item> createMenuItems(LinksOfTheWeekView linksOfTheWeekView) {
-        List<LinksOfTheWeek> linksOfTheWeek = DataRepository.getInstance().getLinksOfTheWeek();
-        List<LinksOfTheWeek> weeks = new ArrayList<>(linksOfTheWeek);
-
-        return weeks
+        return getCategoryItems()
                 .stream()
-                .sorted(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed())
                 .limit(20)
-                .map(links -> new MenuView.Item(DATE_FORMATTER.format(links.getCreatedOn()), null, null, () -> linksOfTheWeekView.goToPage(linksOfTheWeek.size() - linksOfTheWeek.indexOf(links) - 1)))
+                .map(link -> new MenuView.Item(DATE_FORMATTER.format(link.getCreatedOn()), null, null, () -> {
+                    navigateToLinkOfTheWeek(link);
+                }))
                 .toList();
+    }
+
+    private void navigateToLinkOfTheWeek(LinksOfTheWeek linksOfTheWeek) {
+        String url = PagePath.LINKS + linksOfTheWeek.getId().substring(linksOfTheWeek.getId().lastIndexOf("/"));
+        LinkUtil.gotoPage(getSessionManager(), url);
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/LinksOfTheWeekView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/LinksOfTheWeekView.java
@@ -3,45 +3,46 @@ package com.dlsc.jfxcentral2.components;
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.model.Size;
-import com.dlsc.jfxcentral2.utils.NodeUtil;
-import com.dlsc.jfxcentral2.utils.WebAPIUtil;
-import com.jpro.webapi.WebAPI;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ListProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.bootstrapicons.BootstrapIcons;
 import org.kordamp.ikonli.javafx.FontIcon;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class LinksOfTheWeekView extends PaneBase {
 
     private final PaginationControl2 pagination;
-    private final VBox linksBox;
-    private Label dateLabel;
-    private Node scrollAnchorNode;
+    private final LinksOfTheWeek lotw;
 
-    public LinksOfTheWeekView() {
+    public LinksOfTheWeekView(LinksOfTheWeek lotw) {
         getStyleClass().add("links-of-the-week-view");
+        this.lotw = lotw;
 
-        linksBox = new VBox(createPaginationTitleBox());
+        VBox linksBox = new VBox(createPaginationTitleBox());
         linksBox.getStyleClass().add("links-box");
+
+        CustomMarkdownView markdownView = new CustomMarkdownView();
+        markdownView.setMdString(DataRepository.getInstance().getLinksOfTheWeekReadMe(lotw));
+        markdownView.setPrefHeight(markdownView.getWidth());
+        linksBox.getChildren().add(markdownView);
 
         pagination = new PaginationControl2();
         pagination.getStyleClass().add("pagination");
@@ -54,7 +55,6 @@ public class LinksOfTheWeekView extends PaneBase {
         pagination.setPrefHeight(Region.USE_PREF_SIZE);
         selectedIndex.bind(pagination.currentPageIndexProperty());
         linksOfTheWeeksProperty().addListener((ob, ov, nv) -> createFactory());
-        weekCountProperty().addListener((ob, ov, nv) -> createFactory());
         sizeProperty().addListener((ob, ov, nv) -> createFactory());
     }
 
@@ -68,10 +68,12 @@ public class LinksOfTheWeekView extends PaneBase {
         previousButton.managedProperty().bind(previousButton.visibleProperty());
         previousButton.visibleProperty().bind(sizeProperty().map(s -> s != Size.LARGE));
 
-        dateLabel = new Label();
+        Label dateLabel = new Label();
         dateLabel.getStyleClass().add("date-label");
         dateLabel.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(dateLabel, Priority.ALWAYS);
+
+        dateLabel.setText(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(lotw.getCreatedOn()));
 
         Button nextButton = new Button();
         nextButton.getStyleClass().add("next-button");
@@ -92,59 +94,19 @@ public class LinksOfTheWeekView extends PaneBase {
 
     private void createFactory() {
         pagination.setMaxPageIndicatorCount(isSmall() ? 2 : 3);
-        List<LinksOfTheWeek> sortedList = getSortedList();
-        pagination.setPageCount((int) Math.ceil((double) sortedList.size() / getWeekCount()));
-        pagination.setPageFactory((pageIndex) -> {
-            linksBox.getChildren().remove(1, linksBox.getChildren().size());
-            int fromIndex = pageIndex * getWeekCount();
-            int toIndex = Math.min(fromIndex + getWeekCount(), getLinksOfTheWeeks().size());
-            List<LinksOfTheWeek> links = sortedList.subList(fromIndex, toIndex);
-            links.forEach(week -> {
-                dateLabel.setText(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).format(week.getCreatedOn()));
+        List<LinksOfTheWeek> linksOfTheWeeks = getLinksOfTheWeeks();
+        pagination.setPageCount(linksOfTheWeeks.size());
 
-                CustomMarkdownView markdownView = new CustomMarkdownView();
-                markdownView.setMdString(DataRepository.getInstance().getLinksOfTheWeekReadMe(week));
-                markdownView.setPrefHeight(markdownView.getWidth());
+        LinksOfTheWeek currentLotw = linksOfTheWeeks.stream().filter(l -> StringUtils.equals(l.getId(), lotw.getId())).findFirst().orElse(null);
+        int currentPageIndex = currentLotw == null ? -1 : linksOfTheWeeks.indexOf(currentLotw);
+        pagination.setCurrentPageIndex(currentPageIndex);
 
-                VBox weekBox = new VBox(markdownView);
-                weekBox.getStyleClass().add("week-box");
-                linksBox.getChildren().add(weekBox);
-            });
-
-            if (WebAPI.isBrowser()) {
-                if (scrollAnchorNode != null) {
-                    WebAPIUtil.scrollToTop(scrollAnchorNode, false);
-                }
-            } else {
-                if (scrollAnchorNode == null) {
-                    scrollAnchorNode = pagination.getScene().lookup(".links-of-the-week-header");
-                }
-                NodeUtil.scrollToNode(scrollAnchorNode, 80);
+        pagination.setPageFactory(pageIndex -> {
+            if (pageIndex != currentPageIndex) {
+                goToPage(pageIndex);
             }
             return null;
         });
-        pagination.setCurrentPageIndex(0);
-    }
-
-    protected List<LinksOfTheWeek> getSortedList() {
-        return DataRepository.getInstance().getLinksOfTheWeek()
-                .stream()
-                .sorted(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed())
-                .toList();
-    }
-
-    private final IntegerProperty weekCount = new SimpleIntegerProperty(this, "weekCount", 1);
-
-    public int getWeekCount() {
-        return weekCount.get();
-    }
-
-    public IntegerProperty weekCountProperty() {
-        return weekCount;
-    }
-
-    public void setWeekCount(int weekCount) {
-        this.weekCount.set(weekCount);
     }
 
     private final ListProperty<LinksOfTheWeek> linksOfTheWeeks = new SimpleListProperty<>(this, "linksOfTheWeeks", FXCollections.observableArrayList());
@@ -162,21 +124,41 @@ public class LinksOfTheWeekView extends PaneBase {
     }
 
     public void goToPage(int pageIndex) {
-        pagination.setCurrentPageIndex(pageIndex);
+        if (pageIndex >= 0 && pageIndex < getLinksOfTheWeeks().size()) {
+            doGoToPageAction(pageIndex);
+        }
     }
 
     public void goToNextPage() {
         int nextPageIndex = Math.min(pagination.getCurrentPageIndex() + 1, pagination.getPageCount() - 1);
         if (nextPageIndex != pagination.getCurrentPageIndex()) {
-            pagination.setCurrentPageIndex(nextPageIndex);
+            doGoToPageAction(nextPageIndex);
         }
     }
 
     public void goToPreviousPage() {
         int previousPageIndex = Math.max(pagination.getCurrentPageIndex() - 1, 0);
         if (previousPageIndex != pagination.getCurrentPageIndex()) {
-            pagination.setCurrentPageIndex(previousPageIndex);
+            doGoToPageAction(previousPageIndex);
         }
+    }
+
+    private void doGoToPageAction(int pageIndex) {
+        getOnGoToLinkOfTheWeek().accept(getLinksOfTheWeeks().get(pageIndex));
+    }
+
+    private final ObjectProperty<Consumer<LinksOfTheWeek>> onGoToLinkOfTheWeek = new SimpleObjectProperty<>(this, "onGoToLinkOfTheWeek");
+
+    public Consumer<LinksOfTheWeek> getOnGoToLinkOfTheWeek() {
+        return onGoToLinkOfTheWeek.get();
+    }
+
+    public void setOnGoToLinkOfTheWeek(Consumer<LinksOfTheWeek> onGoToLinkOfTheWeek) {
+        this.onGoToLinkOfTheWeek.set(onGoToLinkOfTheWeek);
+    }
+
+    public ObjectProperty<Consumer<LinksOfTheWeek>> onGoToLinkOfTheWeekProperty() {
+        return onGoToLinkOfTheWeek;
     }
 
     private final ReadOnlyIntegerWrapper selectedIndex = new ReadOnlyIntegerWrapper(this, "selectedIndex", 0);

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -7173,15 +7173,15 @@
     -fx-pref-width: 317px;
 }
 
-.links-of-the-week-view .links-box .week-box {
+.links-of-the-week-view .links-box {
     -fx-background-color: -white;
 }
 
-.links-of-the-week-view:md-lg .links-box .week-box .custom-markdown-view {
+.links-of-the-week-view:md-lg .links-box .custom-markdown-view {
     -fx-padding: 20px 30px;
 }
 
-.links-of-the-week-view:sm .links-box .week-box .custom-markdown-view {
+.links-of-the-week-view:sm .links-box .custom-markdown-view {
     -fx-padding: 20px 15px;
 }
 

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloLinksOfTheWeekView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloLinksOfTheWeekView.java
@@ -1,5 +1,6 @@
 package com.dlsc.jfxcentral2.demo.components;
 
+import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.LinksOfTheWeek;
 import com.dlsc.jfxcentral2.components.LinksOfTheWeekView;
 import com.dlsc.jfxcentral2.components.SizeComboBox;
@@ -9,7 +10,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public class HelloLinksOfTheWeekView extends JFXCentralSampleBase {
@@ -18,8 +19,12 @@ public class HelloLinksOfTheWeekView extends JFXCentralSampleBase {
 
     @Override
     protected Region createControl() {
-        view = new LinksOfTheWeekView();
-        view.getLinksOfTheWeeks().setAll(createLinksOfTheWeeks());
+        List<LinksOfTheWeek> links = DataRepository.getInstance().getLinksOfTheWeek();
+        links.sort(Comparator.comparing(LinksOfTheWeek::getCreatedOn).reversed());
+        LinksOfTheWeek latestLotw = links.get(0);
+
+        view = new LinksOfTheWeekView(latestLotw);
+        view.getLinksOfTheWeeks().setAll(links);
         return new ScrollPane(new StackPane(view));
     }
 
@@ -27,28 +32,7 @@ public class HelloLinksOfTheWeekView extends JFXCentralSampleBase {
     public Node getControlPanel() {
         SizeComboBox sizeComboBox = new SizeComboBox();
         view.sizeProperty().bind(sizeComboBox.valueProperty());
-        //weekCount bind size
-        view.weekCountProperty().bind(sizeComboBox.valueProperty().map(size -> size.isLarge() ? 3 : 1));
         return sizeComboBox;
-    }
-
-    private List<LinksOfTheWeek> createLinksOfTheWeeks() {
-        List<LinksOfTheWeek> list = new ArrayList<>();
-        for (int i = 0; i < 15; i++) {
-            LinksOfTheWeek week = new LinksOfTheWeek();
-            week.setName("[" + (i + 1) + "] 16 jan - 22 jan 2023");
-            week.setDescription("""
-                    #### Hello World
-                    Foojay.io, the website for Friends Of OpenJDK, published the podcast ‘The State of JavaFX Framework, Libraries, and Projects’. These guests spoke about the JavaFX framework itself, but also about the libraries and applications that are built with it:
-                    > Pedro Duque Vieira
-                     
-                    Are you considering to write a JavaFX Mastodon client? Take a look at the Bigbone project, that aims to implement the Mastodon API project by André Gasser. \n
-                    Are you considering to write a JavaFX Mastodon client? Take a look at the Bigbone project, that aims to implement the Mastodon API project by André Gasser. \n
-                    """);
-            list.add(week);
-        }
-
-        return list;
     }
 
     @Override


### PR DESCRIPTION
This PR adds support for direct links to specific dates, e.g. /links/2024-07-28, allowing users to navigate directly to a given "Links of the Week" entry.

- #654 