### PR TITLE
Prevent client URL handler addition in non-browser environments

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -229,7 +229,7 @@ public class JFXCentral2App extends Application {
         }
 
         // add client URL handler
-        if (OSUtil.isAWTSupported()) {
+        if (!WebAPI.isBrowser() && OSUtil.isAWTSupported()) {
             addClientUrlHandler(scene, sessionManager);
         }
 


### PR DESCRIPTION
Seemed related exception and OOM on JPro Server.
Better to remove it.