### PR TITLE
Improve icon search by allowing filtering by selected icon packs

### DIFF
--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/MobileRefreshPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/MobileRefreshPage.java
@@ -2,32 +2,23 @@ package com.dlsc.jfxcentral2.app.pages;
 
 import animatefx.animation.FadeIn;
 import animatefx.animation.FadeOut;
-import animatefx.animation.GlowBackground;
-import animatefx.animation.SlideOutUp;
-import animatefx.animation.Tada;
-import animatefx.animation.Wobble;
 import com.dlsc.jfxcentral2.app.RepositoryManager;
 import com.dlsc.jfxcentral2.app.utils.RepositoryUpdater;
 import com.dlsc.jfxcentral2.components.CustomImageView;
 import com.dlsc.jfxcentral2.mobile.components.IntroPane;
-import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.MobileLinkUtil;
 import com.dlsc.jfxcentral2.utils.PagePath;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.ObjectProperty;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.scene.text.TextAlignment;
-import javafx.util.Duration;
-import one.jpro.jproutils.treeshowing.TreeShowing;
 
 public class MobileRefreshPage extends StackPane {
 

--- a/app/src/main/java/module-info.java
+++ b/app/src/main/java/module-info.java
@@ -89,7 +89,6 @@ open module com.dlsc.jfxcentral2.app {
     requires org.kordamp.ikonli.zondicons;
     requires com.gluonhq.attach.util;
     requires com.dlsc.jfxcentral2.mobile;
-    requires jpro.utils.treeshowing;
     requires animatefx;
 
     exports com.dlsc.jfxcentral2.app;

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/CustomMarkdownView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/CustomMarkdownView.java
@@ -10,14 +10,13 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.web.WebView;
-import one.jpro.jproutils.treeshowing.TreeShowing;
 import one.jpro.platform.mdfx.MarkdownView;
 import one.jpro.platform.mdfx.extensions.ImageExtension;
 import one.jpro.platform.mdfx.extensions.YoutubeExtension;
+import one.jpro.platform.utils.TreeShowing;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -310,7 +310,7 @@ public class PacksIconsView extends PaneBase {
         comboBox.setConverter(new StringConverter<>() {
             @Override
             public String toString(Sort object) {
-                return object == Sort.FROM_A_TO_Z ? "From A to Z" : "From Z to A";
+                return object == Sort.FROM_A_TO_Z ? "A → Z" : "Z → A";
             }
 
             @Override
@@ -344,15 +344,15 @@ public class PacksIconsView extends PaneBase {
     private SelectionBox<IkonliPack> initIkonliPackSelection() {
         ObservableList<IkonliPack> packs = FXCollections.observableArrayList(DataRepository.getInstance().getIkonliPacks());
         SelectionBox<IkonliPack> selectionBox = new SelectionBox<>(packs);
-        selectionBox.setPromptText("Select packs");
+        selectionBox.setPromptText("Select");
         selectionBox.setItemConverter(new SimpleStringConverter<>(IkonliPack::getName));
         selectionBox.setSelectedItemsConverter(new SimpleStringConverter<>(list -> {
             if (list.isEmpty()) {
-                return "Select packs";
-            } else if (list.size() == 1) {
-                return list.get(0).getName();
+                return "Select";
+            } else if (list.size() == selectionBox.getItems().size()) {
+                return "All";
             } else {
-                return list.size() + " packs";
+                return String.valueOf(list.size());
             }
         }));
         selectionBox.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -20,6 +20,9 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
@@ -35,7 +38,10 @@ import javafx.util.StringConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 
 public class PacksIconsView extends PaneBase {
 
@@ -355,9 +361,99 @@ public class PacksIconsView extends PaneBase {
                 return String.valueOf(list.size());
             }
         }));
+        selectionBox.setTop(createExtraButtonsBox(selectionBox));
         selectionBox.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         selectionBox.getSelectionModel().selectAll();
         return selectionBox;
+    }
+
+    private Node createExtraButtonsBox(SelectionBox<IkonliPack> selectionBox) {
+        Button clearButton = selectionBox.createExtraButton("Clear", null);
+        clearButton.getStyleClass().add("clear-button");
+        clearButton.setOnAction(e -> selectionBox.getSelectionModel().clearSelection());
+
+        Button selectAllButton = selectionBox.createExtraButton("Select All", () -> selectionBox.getSelectionModel().selectAll());
+        selectAllButton.managedProperty().bind(selectAllButton.visibleProperty());
+        selectAllButton.visibleProperty().bind(selectionBox.currentSelectionModeProperty().isEqualTo(SelectionMode.MULTIPLE));
+        selectAllButton.getStyleClass().add("select-all-button");
+
+        Button materialDesignAZ = createSelectMaterialDesignAZButton(selectionBox);
+
+        Button material2Variants = createSelectMaterial2VariantsButton(selectionBox);
+
+        VBox actionBox = new VBox(clearButton, selectAllButton, material2Variants, materialDesignAZ);
+        actionBox.managedProperty().bind(actionBox.visibleProperty());
+        actionBox.visibleProperty().bind(selectionBox.itemsProperty().emptyProperty().not());
+
+        Label quickSelectLabel = new Label("QUICK SELECT");
+        quickSelectLabel.getStyleClass().add("quick-select-label");
+        quickSelectLabel.setRotate(-90);
+
+        HBox extraButtonsBox = new HBox(new Group(quickSelectLabel), actionBox);
+        extraButtonsBox.getStyleClass().add("extra-buttons-box");
+
+        return extraButtonsBox;
+    }
+
+    private Button createSelectMaterial2VariantsButton(SelectionBox<IkonliPack> selectionBox) {
+        return selectionBox.createExtraButton("Select Material2 Variants", () -> {
+            selectionBox.getSelectionModel().clearSelection();
+
+            List<IkonliPack> items = selectionBox.getItems();
+            List<Integer> indices = new ArrayList<>();
+
+            String prefix = "Material2";
+
+            for (int i = 0; i < items.size(); i++) {
+                IkonliPack pack = items.get(i);
+                String name = Objects.requireNonNullElse(pack.getName(), "");
+
+                if (name.startsWith(prefix)) {
+                    indices.add(i);
+                }
+            }
+
+            if (!indices.isEmpty()) {
+                selectionBox.getSelectionModel().selectIndices(
+                        indices.get(0),
+                        indices.size() > 1
+                                ? indices.subList(1, indices.size()).stream().mapToInt(Integer::intValue).toArray()
+                                : new int[0]
+                );
+            }
+        });
+    }
+
+    private Button createSelectMaterialDesignAZButton(SelectionBox<IkonliPack> selectionBox) {
+        return selectionBox.createExtraButton("Select MaterialDesign A–Z", () -> {
+            selectionBox.getSelectionModel().clearSelection();
+
+            List<IkonliPack> items = selectionBox.getItems();
+            List<Integer> indices = new ArrayList<>();
+
+            String prefix = "MaterialDesign";
+            int expectedLength = prefix.length() + 1;
+
+            for (int i = 0; i < items.size(); i++) {
+                IkonliPack pack = items.get(i);
+                String name = Objects.requireNonNullElse(pack.getName(), "");
+
+                if (name.startsWith(prefix)
+                        && name.length() == expectedLength
+                        && Character.isUpperCase(name.charAt(prefix.length()))) {
+                    indices.add(i);
+                }
+            }
+
+            if (!indices.isEmpty()) {
+                selectionBox.getSelectionModel().selectIndices(
+                        indices.get(0),
+                        indices.size() > 1
+                                ? indices.subList(1, indices.size()).stream().mapToInt(Integer::intValue).toArray()
+                                : new int[0]
+                );
+            }
+        });
     }
 
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
@@ -159,21 +159,18 @@ public class IkonliPackUtil {
         if (packs == null || packs.isEmpty()) {
             return Collections.emptyList();
         }
-        long start = System.currentTimeMillis();
 
         Set<String> packNames = packs.stream()
                 .map(IkonliPack::getName)
                 .collect(Collectors.toSet());
 
-        List<Ikon> list = dataMap.entrySet().stream()
+        return dataMap.entrySet().stream()
                 .filter(entry -> {
                     IkonData data = entry.getValue();
                     return data.getIkonliPack() != null && packNames.contains(data.getIkonliPack().getName());
                 })
                 .map(Map.Entry::getKey)
                 .toList();
-        System.out.println("IkonliPackUtil.getIkonsForPacksFiltered took " + (System.currentTimeMillis() - start) + "ms");
-        return list;
     }
 
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/IkonliPackUtil.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.IkonProvider;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 public class IkonliPackUtil {
 
@@ -25,6 +28,7 @@ public class IkonliPackUtil {
     private final Map<Ikon, IkonData> dataMap = new HashMap<>();
     private final Map<String, IkonData> nameMap = new HashMap<>();
     private final Set<IkonData> ikonDataSet = new TreeSet<>();
+    private Set<Ikon> allIkons;
 
     private IkonliPackUtil() {
         if (null != IkonProvider.class.getModule().getLayer()) {
@@ -128,6 +132,48 @@ public class IkonliPackUtil {
             }
         }
         return Optional.empty();
+    }
+
+    /**
+     * Retrieves all available Ikons as an unmodifiable set. If the set has not
+     * been initialized yet, it is created from the keys of the data map and
+     * cached for future access.
+     *
+     * @return a set containing all available Ikons
+     */
+    public Set<Ikon> getAllIkons() {
+        if (allIkons == null) {
+            allIkons = Collections.unmodifiableSet(dataMap.keySet());
+        }
+        return allIkons;
+    }
+
+
+    /**
+     * Filters and retrieves a list of Ikons that belong to the specified collection of IkonliPacks.
+     *
+     * @param packs the collection of IkonliPacks to filter Ikons by; if null or empty, the method returns an empty list
+     * @return a list of Ikons associated with the specified IkonliPacks, or an empty list if no matching Ikons are found
+     */
+    public List<Ikon> getIkonsForPacksFiltered(Collection<IkonliPack> packs) {
+        if (packs == null || packs.isEmpty()) {
+            return Collections.emptyList();
+        }
+        long start = System.currentTimeMillis();
+
+        Set<String> packNames = packs.stream()
+                .map(IkonliPack::getName)
+                .collect(Collectors.toSet());
+
+        List<Ikon> list = dataMap.entrySet().stream()
+                .filter(entry -> {
+                    IkonData data = entry.getValue();
+                    return data.getIkonliPack() != null && packNames.contains(data.getIkonliPack().getName());
+                })
+                .map(Map.Entry::getKey)
+                .toList();
+        System.out.println("IkonliPackUtil.getIkonsForPacksFiltered took " + (System.currentTimeMillis() - start) + "ms");
+        return list;
     }
 
 }

--- a/components/src/main/java/module-info.java
+++ b/components/src/main/java/module-info.java
@@ -98,7 +98,6 @@ open module com.dlsc.jfxcentral2.components {
     requires org.kordamp.ikonli.zondicons;
     requires com.rometools.rome;
     requires java.prefs;
-    requires jpro.utils.treeshowing;
     // ikonli icon packs END
 
     exports com.dlsc.jfxcentral2.components;

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -9365,7 +9365,7 @@
     -fx-background-radius: 10px;
     -fx-effect: dropshadow(gaussian, rgba(14, 74, 228, 0.25), 10, 0.2, 0, 0);
     -fx-padding: 20px 5px;
-    -fx-max-height: 25em;
+    -fx-max-height: 32em;
     -fx-translate-y: 8px;
 }
 

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -9339,6 +9339,77 @@
     -fx-font-weight: normal;
 }
 
+.packs-icons-view:md-lg .top-box .combo-box-wrapper .scope-combo-box {
+    -fx-pref-width: 118px;
+}
+
+.packs-icons-view:md-lg .top-box .combo-box-wrapper .selection-box {
+    -fx-pref-width: 128px;
+}
+
+.packs-icons-view:md-lg .top-box .combo-box-wrapper .sort-combo-box {
+    -fx-pref-width: 115px;
+}
+
+.packs-icons-view .top-box .selection-box:empty .display-label {
+    -fx-text-fill: -orange;
+}
+
+/** ---------------------------------
+ * SelectionPopup
+ */
+.selection-popup {
+}
+
+.selection-popup > .content {
+    -fx-background-radius: 10px;
+    -fx-effect: dropshadow(gaussian, rgba(14, 74, 228, 0.25), 10, 0.2, 0, 0);
+    -fx-padding: 20px 5px;
+    -fx-max-height: 25em;
+    -fx-translate-y: 8px;
+}
+
+
+.selection-popup > .content .extra-buttons-box .extra-button {
+    -fx-text-fill: -grey-100;
+    -fx-pref-height: 35px;
+}
+
+.selection-popup > .content .extra-buttons-box .extra-button:hover {
+    -fx-background-color: -bright-blue;
+    -fx-text-fill: -white;
+}
+
+.selection-popup > .content .extra-buttons-box .extra-button:pressed {
+    -fx-background-color: -light-blue;
+}
+
+.selection-popup > .content > .options-scroll-pane {
+    -fx-padding: 0;
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box {
+    -fx-spacing: 3px;
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box > .check-box {
+    -fx-cursor: hand;
+    -fx-label-padding: 0 0 0 4px;
+    -fx-text-fill: -grey-100;
+    -fx-padding: 3px 5px;
+    -fx-border-width: 0;
+    -fx-pref-height: 45px;
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box > .check-box:hover {
+    -fx-background-color: transparent;
+}
+
+.selection-popup > .content > .options-scroll-pane .options-box > .check-box:selected {
+    -fx-background-color: derive(-grey-10, 50%);
+    -fx-text-fill: -grey-100;
+}
+
 /* ----------------------------------------------------------------------------
  * ScrollPane
  */

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -9372,6 +9372,7 @@
 
 .selection-popup > .content .extra-buttons-box .extra-button {
     -fx-text-fill: -grey-100;
+    -fx-padding: 4px 15px;
     -fx-pref-height: 35px;
 }
 
@@ -9382,6 +9383,7 @@
 
 .selection-popup > .content .extra-buttons-box .extra-button:pressed {
     -fx-background-color: -light-blue;
+    -fx-text-fill: -grey-100;
 }
 
 .selection-popup > .content > .options-scroll-pane {
@@ -9408,6 +9410,16 @@
 .selection-popup > .content > .options-scroll-pane .options-box > .check-box:selected {
     -fx-background-color: derive(-grey-10, 50%);
     -fx-text-fill: -grey-100;
+}
+
+.selection-popup > .content .extra-buttons-box {
+    -fx-alignment: center;
+    -fx-spacing: 5px;
+}
+
+.selection-popup > .content .quick-select-label {
+    -fx-padding: 0 0 0 5px;
+    -fx-text-fill: -grey-30;
 }
 
 /* ----------------------------------------------------------------------------

--- a/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
+++ b/components/src/main/resources/com/dlsc/jfxcentral2/theme.css
@@ -9325,6 +9325,11 @@
     -fx-padding: 10px 30px;
 }
 
+.packs-icons-view .top-box .selection-box .display-label {
+    -fx-font-family: "Spline Sans";
+    -fx-font-weight: normal;
+}
+
 /* ----------------------------------------------------------------------------
  * ScrollPane
  */

--- a/mobile/src/main/java/module-info.java
+++ b/mobile/src/main/java/module-info.java
@@ -97,7 +97,6 @@ open module com.dlsc.jfxcentral2.mobile {
     requires org.kordamp.ikonli.zondicons;
     requires com.rometools.rome;
     requires com.dlsc.jfxcentral2.components;
-    requires jpro.utils.treeshowing;
     // ikonli icon packs END
 
     exports com.dlsc.jfxcentral2.mobile.home;

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
             <dependency>
                 <groupId>com.dlsc.gemsfx</groupId>
                 <artifactId>gemsfx</artifactId>
-                <version>2.47.0</version>
+                <version>2.96.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
             <dependency>
                 <groupId>com.dlsc.gemsfx</groupId>
                 <artifactId>gemsfx</artifactId>
-                <version>2.96.0</version>
+                <version>2.103.0</version>
             </dependency>
 
             <dependency>

--- a/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloSearchIkonGridView.java
+++ b/sampler/src/main/java/com/dlsc/jfxcentral2/demo/components/HelloSearchIkonGridView.java
@@ -33,7 +33,7 @@ public class HelloSearchIkonGridView extends JFXCentralSampleBase {
         ikonGridView.sizeProperty().bind(sizeComboBox.valueProperty());
         TextField searchField = new TextField();
         searchField.setPromptText("Search");
-        Set<Ikon> ikons = IkonliPackUtil.getInstance().getDataMap().keySet();
+        Set<Ikon> ikons = IkonliPackUtil.getInstance().getAllIkons();
         System.out.println(ikons.size());
         ikonGridView.itemsProperty().bind(Bindings.createObjectBinding(()->
                 FXCollections.observableArrayList(ikons.stream().filter(it -> StringUtils.containsIgnoreCase( it.getDescription(),searchField.getText().trim()))


### PR DESCRIPTION
### Summary

This PR enhances the icon search functionality by allowing users to filter results by selected icon packs.

### Before

- All icon results from all packs were shown when searching by keyword (e.g. `arrow`)
- This led to overwhelming and often irrelevant matches, especially with common keywords

### After

- A `SelectionBox` UI control is added to let users pick one or more icon packs (e.g., MaterialDesign, IcoMoon, FontAwesome)
- The search now returns icons only from the selected packs, making results more precise and manageable

### Benefits

- Improved usability of the icon explorer
- Better performance when dealing with large icon sets
- Easier to discover relevant icons in specific design systems

### Notes

By default, all icon packs are selected, so the search still behaves as before — matching icons across all available packs

![image](https://github.com/user-attachments/assets/c8a6085d-acc2-4ae2-a428-233a249c012e)
![image](https://github.com/user-attachments/assets/92eb92c1-6ebe-410c-84b3-e4cd051e6473)

