### PR TITLE
Support query parameters for shareable filter links

### DIFF
--- a/.launchers/JFXCentral2App (develop).run.xml
+++ b/.launchers/JFXCentral2App (develop).run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="JFXCentral2App (develop)" type="Application" factoryName="Application" singleton="true">
     <option name="MAIN_CLASS_NAME" value="com.dlsc.jfxcentral2.app.JFXCentral2App" />
     <module name="app" />
-    <option name="VM_PARAMETERS" value="-Ddevelop=true -Dsocial=false" />
+    <option name="VM_PARAMETERS" value="-Ddevelop=true -Dsocial=false -Djavafx.enablePreview=true" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.dlsc.jfxcentral2.app.stage.*" />

--- a/.launchers/JFXCentral2App (develop).run.xml
+++ b/.launchers/JFXCentral2App (develop).run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="JFXCentral2App (develop)" type="Application" factoryName="Application" singleton="true">
     <option name="MAIN_CLASS_NAME" value="com.dlsc.jfxcentral2.app.JFXCentral2App" />
     <module name="app" />
-    <option name="VM_PARAMETERS" value="-Ddevelop=true -Dsocial=false -Djavafx.enablePreview=true" />
+    <option name="VM_PARAMETERS" value="-Ddevelop=true -Dsocial=false" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.dlsc.jfxcentral2.app.stage.*" />

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -302,21 +302,21 @@ public class JFXCentral2App extends Application {
                         return Response.empty();
                     }
                 })
-                .and(createCategoryOrDetailRoute(PagePath.BLOGS, Blog.class, r -> new BlogsCategoryPage(size, PageRequest.of(r)), id -> new BlogDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.BOOKS, Book.class, r -> new BooksCategoryPage(size, PageRequest.of(r)), id -> new BookDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.COMPANIES, Company.class, r -> new CompaniesCategoryPage(size, PageRequest.of(r)), id -> new CompanyDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.DOWNLOADS, Download.class, r -> new DownloadsCategoryPage(size, PageRequest.of(r)), id -> new DownloadDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.LIBRARIES, Library.class, r -> new LibrariesCategoryPage(size, PageRequest.of(r)), id -> new LibraryDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.PEOPLE, Person.class, r -> new PeopleCategoryPage(size, PageRequest.of(r)), id -> new PersonDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.SHOWCASES, RealWorldApp.class, r -> new ShowcasesCategoryPage(size, PageRequest.of(r)), id -> new ShowcaseDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TIPS, Tip.class, r -> new TipCategoryPage(size, PageRequest.of(r)), id -> new TipDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TOOLS, Tool.class, r -> new ToolsCategoryPage(size, PageRequest.of(r)), id -> new ToolDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TUTORIALS, Tutorial.class, r -> new TutorialsCategoryPage(size, PageRequest.of(r)), id -> new TutorialDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.VIDEOS, Video.class, r -> new VideosCategoryPage(size, PageRequest.of(r)), id -> new VideoDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.UTILITIES, Utility.class, r -> new UtilitiesCategoryPage(size, PageRequest.of(r)), id -> new UtilityDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_JAVAFX, LearnJavaFX.class, r -> new LearnJavaFXCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnJavaFX.class, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_MOBILE, LearnMobile.class, r -> new LearnMobileCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnMobile.class, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_RASPBERRYPI, LearnRaspberryPi.class, r -> new LearnRaspberryPiCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnRaspberryPi.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.BLOGS, Blog.class, request -> new BlogsCategoryPage(size, request), id -> new BlogDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.BOOKS, Book.class, request -> new BooksCategoryPage(size, request), id -> new BookDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.COMPANIES, Company.class, request -> new CompaniesCategoryPage(size, request), id -> new CompanyDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.DOWNLOADS, Download.class, request -> new DownloadsCategoryPage(size, request), id -> new DownloadDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.LIBRARIES, Library.class, request -> new LibrariesCategoryPage(size, request), id -> new LibraryDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.PEOPLE, Person.class, request -> new PeopleCategoryPage(size, request), id -> new PersonDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.SHOWCASES, RealWorldApp.class, request -> new ShowcasesCategoryPage(size, request), id -> new ShowcaseDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TIPS, Tip.class, request -> new TipCategoryPage(size, request), id -> new TipDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TOOLS, Tool.class, request -> new ToolsCategoryPage(size, request), id -> new ToolDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TUTORIALS, Tutorial.class, request -> new TutorialsCategoryPage(size, request), id -> new TutorialDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.VIDEOS, Video.class, request -> new VideosCategoryPage(size, request), id -> new VideoDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.UTILITIES, Utility.class, request -> new UtilitiesCategoryPage(size, request), id -> new UtilityDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_JAVAFX, LearnJavaFX.class, request -> new LearnJavaFXCategoryPage(size, request), id -> new LearnDetailsPage(size, LearnJavaFX.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_MOBILE, LearnMobile.class, request -> new LearnMobileCategoryPage(size, request), id -> new LearnDetailsPage(size, LearnMobile.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_RASPBERRYPI, LearnRaspberryPi.class, request -> new LearnRaspberryPiCategoryPage(size, request), id -> new LearnDetailsPage(size, LearnRaspberryPi.class, id)))
                 .and(createIconPackOrDetailRoute(PagePath.ICONS))
                 .and(Route.get(PagePath.CREDITS, r -> Response.view(new CreditsPage(size))))
                 .and(Route.get(PagePath.LEGAL, r -> Response.view(new LegalPage(size, LegalPage.Section.TERMS))))
@@ -325,8 +325,8 @@ public class JFXCentral2App extends Application {
                 .and(Route.get(PagePath.LEGAL_PRIVACY, r -> Response.view(new LegalPage(size, LegalPage.Section.PRIVACY))))
                 .and(createLOTWRoute())
                 .and(Route.get(PagePath.TEAM, r -> Response.view(new TeamPage(size))))
-                .and(Route.get(PagePath.OPENJFX, r -> Response.view(new OpenJFXPage(size, PageRequest.of(r)))))
-                .and(Route.get(PagePath.DOCUMENTATION, r -> Response.view(new DocumentationCategoryPage(size, PageRequest.of(r)))))
+                .and(Route.get(PagePath.OPENJFX, r -> Response.view(new OpenJFXPage(size, PageRequest.of(r, PagePath.OPENJFX)))))
+                .and(Route.get(PagePath.DOCUMENTATION, r -> Response.view(new DocumentationCategoryPage(size, PageRequest.of(r, PagePath.DOCUMENTATION)))))
                 .filter(FooterFilter.create(size))
                 .and(Route.get(PagePath.REFRESH, r -> {
                     RepositoryManager.prepareForRefresh();
@@ -380,16 +380,16 @@ public class JFXCentral2App extends Application {
         };
     }
 
-    private Route createCategoryOrDetailRoute(String path, Class<? extends ModelObject> clazz, Function<Request, View> masterResponse, Callback<String, View> detailedResponse) {
+    private Route createCategoryOrDetailRoute(String path, Class<? extends ModelObject> clazz, Function<PageRequest, View> masterResponse, Callback<String, View> detailedResponse) {
         return r -> {
             if (r.getPath().startsWith(path)) {
-                return createResponse(r, clazz, masterResponse, detailedResponse);
+                return createResponse(r, path, clazz, masterResponse, detailedResponse);
             }
             return Response.empty();
         };
     }
 
-    private Response createResponse(Request request, Class<? extends ModelObject> clazz, Function<Request, View> categoryResponse, Callback<String, View> detailedResponse) {
+    private Response createResponse(Request request, String path, Class<? extends ModelObject> clazz, Function<PageRequest, View> categoryResponse, Callback<String, View> detailedResponse) {
         int index = request.getPath().lastIndexOf("/");
         if (index > 0) {
             String id = request.getPath().substring(index + 1).trim();
@@ -400,7 +400,7 @@ public class JFXCentral2App extends Application {
             return Response.view(detailedResponse.call(id));
         }
 
-        return Response.view(categoryResponse.apply(request));
+        return Response.view(categoryResponse.apply(PageRequest.of(request, path)));
     }
 
     /**
@@ -426,9 +426,9 @@ public class JFXCentral2App extends Application {
                             && IkonliPackUtil.getInstance().getAggregatedPack(id) == null) {
                         return Response.view(new ErrorPage(size, r));
                     }
-                    return Response.view(new IconPackDetailPage(size, id, PageRequest.of(r)));
+                    return Response.view(new IconPackDetailPage(size, id, PageRequest.of(r, path + "/" + id)));
                 }
-                return Response.view(new IconsCategoryPage(size, PageRequest.of(r)));
+                return Response.view(new IconsCategoryPage(size, PageRequest.of(r, path)));
             }
 
             //  Route to SingleIconPage: /icons/{ikonliPackId}/{iconDescription}

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/JFXCentral2App.java
@@ -75,6 +75,7 @@ import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.utils.NodeUtil;
 import com.dlsc.jfxcentral2.utils.OSUtil;
 import com.dlsc.jfxcentral2.utils.PagePath;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.SocialUtil;
 import com.gluonhq.attach.display.DisplayService;
 import com.jpro.webapi.WebAPI;
@@ -115,7 +116,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public class JFXCentral2App extends Application {
 
@@ -301,21 +302,21 @@ public class JFXCentral2App extends Application {
                         return Response.empty();
                     }
                 })
-                .and(createCategoryOrDetailRoute(PagePath.BLOGS, Blog.class, () -> new BlogsCategoryPage(size), id -> new BlogDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.BOOKS, Book.class, () -> new BooksCategoryPage(size), id -> new BookDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.COMPANIES, Company.class, () -> new CompaniesCategoryPage(size), id -> new CompanyDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.DOWNLOADS, Download.class, () -> new DownloadsCategoryPage(size), id -> new DownloadDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.LIBRARIES, Library.class, () -> new LibrariesCategoryPage(size), id -> new LibraryDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.PEOPLE, Person.class, () -> new PeopleCategoryPage(size), id -> new PersonDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.SHOWCASES, RealWorldApp.class, () -> new ShowcasesCategoryPage(size), id -> new ShowcaseDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TIPS, Tip.class, () -> new TipCategoryPage(size), id -> new TipDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TOOLS, Tool.class, () -> new ToolsCategoryPage(size), id -> new ToolDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.TUTORIALS, Tutorial.class, () -> new TutorialsCategoryPage(size), id -> new TutorialDetailsPage(size, id))) // new routing for showcases
-                .and(createCategoryOrDetailRoute(PagePath.VIDEOS, Video.class, () -> new VideosCategoryPage(size), id -> new VideoDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.UTILITIES, Utility.class, () -> new UtilitiesCategoryPage(size), id -> new UtilityDetailsPage(size, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_JAVAFX, LearnJavaFX.class, () -> new LearnJavaFXCategoryPage(size), id -> new LearnDetailsPage(size, LearnJavaFX.class, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_MOBILE, LearnMobile.class, () -> new LearnMobileCategoryPage(size), id -> new LearnDetailsPage(size, LearnMobile.class, id)))
-                .and(createCategoryOrDetailRoute(PagePath.LEARN_RASPBERRYPI, LearnRaspberryPi.class, () -> new LearnRaspberryPiCategoryPage(size), id -> new LearnDetailsPage(size, LearnRaspberryPi.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.BLOGS, Blog.class, r -> new BlogsCategoryPage(size, PageRequest.of(r)), id -> new BlogDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.BOOKS, Book.class, r -> new BooksCategoryPage(size, PageRequest.of(r)), id -> new BookDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.COMPANIES, Company.class, r -> new CompaniesCategoryPage(size, PageRequest.of(r)), id -> new CompanyDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.DOWNLOADS, Download.class, r -> new DownloadsCategoryPage(size, PageRequest.of(r)), id -> new DownloadDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.LIBRARIES, Library.class, r -> new LibrariesCategoryPage(size, PageRequest.of(r)), id -> new LibraryDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.PEOPLE, Person.class, r -> new PeopleCategoryPage(size, PageRequest.of(r)), id -> new PersonDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.SHOWCASES, RealWorldApp.class, r -> new ShowcasesCategoryPage(size, PageRequest.of(r)), id -> new ShowcaseDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TIPS, Tip.class, r -> new TipCategoryPage(size, PageRequest.of(r)), id -> new TipDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TOOLS, Tool.class, r -> new ToolsCategoryPage(size, PageRequest.of(r)), id -> new ToolDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.TUTORIALS, Tutorial.class, r -> new TutorialsCategoryPage(size, PageRequest.of(r)), id -> new TutorialDetailsPage(size, id))) // new routing for showcases
+                .and(createCategoryOrDetailRoute(PagePath.VIDEOS, Video.class, r -> new VideosCategoryPage(size, PageRequest.of(r)), id -> new VideoDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.UTILITIES, Utility.class, r -> new UtilitiesCategoryPage(size, PageRequest.of(r)), id -> new UtilityDetailsPage(size, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_JAVAFX, LearnJavaFX.class, r -> new LearnJavaFXCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnJavaFX.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_MOBILE, LearnMobile.class, r -> new LearnMobileCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnMobile.class, id)))
+                .and(createCategoryOrDetailRoute(PagePath.LEARN_RASPBERRYPI, LearnRaspberryPi.class, r -> new LearnRaspberryPiCategoryPage(size, PageRequest.of(r)), id -> new LearnDetailsPage(size, LearnRaspberryPi.class, id)))
                 .and(createIconPackOrDetailRoute(PagePath.ICONS))
                 .and(Route.get(PagePath.CREDITS, r -> Response.view(new CreditsPage(size))))
                 .and(Route.get(PagePath.LEGAL, r -> Response.view(new LegalPage(size, LegalPage.Section.TERMS))))
@@ -324,8 +325,8 @@ public class JFXCentral2App extends Application {
                 .and(Route.get(PagePath.LEGAL_PRIVACY, r -> Response.view(new LegalPage(size, LegalPage.Section.PRIVACY))))
                 .and(createLOTWRoute())
                 .and(Route.get(PagePath.TEAM, r -> Response.view(new TeamPage(size))))
-                .and(Route.get(PagePath.OPENJFX, r -> Response.view(new OpenJFXPage(size))))
-                .and(Route.get(PagePath.DOCUMENTATION, r -> Response.view(new DocumentationCategoryPage(size))))
+                .and(Route.get(PagePath.OPENJFX, r -> Response.view(new OpenJFXPage(size, PageRequest.of(r)))))
+                .and(Route.get(PagePath.DOCUMENTATION, r -> Response.view(new DocumentationCategoryPage(size, PageRequest.of(r)))))
                 .filter(FooterFilter.create(size))
                 .and(Route.get(PagePath.REFRESH, r -> {
                     RepositoryManager.prepareForRefresh();
@@ -379,7 +380,7 @@ public class JFXCentral2App extends Application {
         };
     }
 
-    private Route createCategoryOrDetailRoute(String path, Class<? extends ModelObject> clazz, Supplier<View> masterResponse, Callback<String, View> detailedResponse) {
+    private Route createCategoryOrDetailRoute(String path, Class<? extends ModelObject> clazz, Function<Request, View> masterResponse, Callback<String, View> detailedResponse) {
         return r -> {
             if (r.getPath().startsWith(path)) {
                 return createResponse(r, clazz, masterResponse, detailedResponse);
@@ -388,7 +389,7 @@ public class JFXCentral2App extends Application {
         };
     }
 
-    private Response createResponse(Request request, Class<? extends ModelObject> clazz, Supplier<View> categoryResponse, Callback<String, View> detailedResponse) {
+    private Response createResponse(Request request, Class<? extends ModelObject> clazz, Function<Request, View> categoryResponse, Callback<String, View> detailedResponse) {
         int index = request.getPath().lastIndexOf("/");
         if (index > 0) {
             String id = request.getPath().substring(index + 1).trim();
@@ -399,7 +400,7 @@ public class JFXCentral2App extends Application {
             return Response.view(detailedResponse.call(id));
         }
 
-        return Response.view(categoryResponse.get());
+        return Response.view(categoryResponse.apply(request));
     }
 
     /**
@@ -425,9 +426,9 @@ public class JFXCentral2App extends Application {
                             && IkonliPackUtil.getInstance().getAggregatedPack(id) == null) {
                         return Response.view(new ErrorPage(size, r));
                     }
-                    return Response.view(new IconPackDetailPage(size, id));
+                    return Response.view(new IconPackDetailPage(size, id, PageRequest.of(r)));
                 }
-                return Response.view(new IconsCategoryPage(size));
+                return Response.view(new IconsCategoryPage(size, PageRequest.of(r)));
             }
 
             //  Route to SingleIconPage: /icons/{ikonliPackId}/{iconDescription}

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/CategoryPageBase.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/CategoryPageBase.java
@@ -10,6 +10,7 @@ import com.dlsc.jfxcentral2.components.headers.CategoryHeader;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.OSUtil;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
@@ -20,8 +21,24 @@ import org.kordamp.ikonli.Ikon;
 
 public abstract class CategoryPageBase<T extends ModelObject> extends PageBase {
 
+    private final PageRequest pageRequest;
+
     public CategoryPageBase(ObjectProperty<Size> size) {
+        this(size, PageRequest.EMPTY);
+    }
+
+    public CategoryPageBase(ObjectProperty<Size> size, PageRequest pageRequest) {
         super(size, Mode.DARK);
+        this.pageRequest = pageRequest == null ? PageRequest.EMPTY : pageRequest;
+    }
+
+    /**
+     * The request this page was created for, carrying the path and the query parameters.
+     *
+     * @return the page request, never {@code null}
+     */
+    protected PageRequest getPageRequest() {
+        return pageRequest;
     }
 
     @Override
@@ -36,6 +53,7 @@ public abstract class CategoryPageBase<T extends ModelObject> extends PageBase {
         // filter
         SearchFilterView<T> filterView = createSearchFilterView();
         filterView.sizeProperty().bind(sizeProperty());
+        filterView.applyQueryParams(pageRequest.params());
         blockingProperty().bind(filterView.blockingProperty());
 
         // data

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/CategoryPageBase.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/CategoryPageBase.java
@@ -54,6 +54,7 @@ public abstract class CategoryPageBase<T extends ModelObject> extends PageBase {
         SearchFilterView<T> filterView = createSearchFilterView();
         filterView.sizeProperty().bind(sizeProperty());
         filterView.applyQueryParams(pageRequest.params());
+        filterView.setCanonicalPath(pageRequest.path());
         blockingProperty().bind(filterView.blockingProperty());
 
         // data

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/OpenJFXPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/OpenJFXPage.java
@@ -9,6 +9,7 @@ import com.dlsc.jfxcentral2.components.PullRequestsView;
 import com.dlsc.jfxcentral2.components.StripView;
 import com.dlsc.jfxcentral2.components.filters.PullRequestsFilterView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -23,8 +24,12 @@ public class OpenJFXPage extends PageBase {
     private final ObservableList<PullRequest> pullRequests;
     private final FilteredList<PullRequest> filteredList;
 
-    public OpenJFXPage(ObjectProperty<Size> size) {
+    private final PageRequest pageRequest;
+
+    public OpenJFXPage(ObjectProperty<Size> size, PageRequest pageRequest) {
         super(size, Mode.LIGHT);
+
+        this.pageRequest = pageRequest == null ? PageRequest.EMPTY : pageRequest;
 
         // data
         pullRequests = FXCollections.observableArrayList();
@@ -60,6 +65,7 @@ public class OpenJFXPage extends PageBase {
         // filter view
         PullRequestsFilterView pullRequestsFilterView = new PullRequestsFilterView();
         pullRequestsFilterView.sizeProperty().bind(sizeProperty());
+        pullRequestsFilterView.applyQueryParams(pageRequest.params());
         pullRequestsFilterView.setDisable(pullRequests.isEmpty());
         blockingProperty().bind(pullRequestsFilterView.blockingProperty());
 

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/OpenJFXPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/OpenJFXPage.java
@@ -66,6 +66,7 @@ public class OpenJFXPage extends PageBase {
         PullRequestsFilterView pullRequestsFilterView = new PullRequestsFilterView();
         pullRequestsFilterView.sizeProperty().bind(sizeProperty());
         pullRequestsFilterView.applyQueryParams(pageRequest.params());
+        pullRequestsFilterView.setCanonicalPath(pageRequest.path());
         pullRequestsFilterView.setDisable(pullRequests.isEmpty());
         blockingProperty().bind(pullRequestsFilterView.blockingProperty());
 

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BlogsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BlogsCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.BlogTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class BlogsCategoryPage extends CategoryPageBase<Blog> {
 
-    public BlogsCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public BlogsCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BooksCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/BooksCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.BookTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class BooksCategoryPage extends CategoryPageBase<Book> {
 
-    public BooksCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public BooksCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/CompaniesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/CompaniesCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.CompanyTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class CompaniesCategoryPage extends CategoryPageBase<Company> {
 
-    public CompaniesCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public CompaniesCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DocumentationCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.DocumentationTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class DocumentationCategoryPage extends CategoryPageBase<Documentation> {
 
-    public DocumentationCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public DocumentationCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DownloadsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/DownloadsCategoryPage.java
@@ -9,6 +9,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.DownloadTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -19,8 +20,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class DownloadsCategoryPage extends CategoryPageBase<Download> {
 
-    public DownloadsCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public DownloadsCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/IconsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/IconsCategoryPage.java
@@ -9,6 +9,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.headers.CategoryHeader;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
@@ -18,8 +19,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class IconsCategoryPage extends CategoryPageBase<IkonliPack> {
 
-    public IconsCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public IconsCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override
@@ -68,6 +69,7 @@ public class IconsCategoryPage extends CategoryPageBase<IkonliPack> {
 
         PacksIconsView packsIconsView = new PacksIconsView();
         packsIconsView.sizeProperty().bind(sizeProperty());
+        packsIconsView.applyQueryParams(getPageRequest().params());
 
         FeaturesContainer featuresContainer = new FeaturesContainer();
         featuresContainer.sizeProperty().bind(sizeProperty());

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/IconsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/IconsCategoryPage.java
@@ -70,6 +70,7 @@ public class IconsCategoryPage extends CategoryPageBase<IkonliPack> {
         PacksIconsView packsIconsView = new PacksIconsView();
         packsIconsView.sizeProperty().bind(sizeProperty());
         packsIconsView.applyQueryParams(getPageRequest().params());
+        packsIconsView.setCanonicalPath(getPageRequest().path());
 
         FeaturesContainer featuresContainer = new FeaturesContainer();
         featuresContainer.sizeProperty().bind(sizeProperty());

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnCategoryPage.java
@@ -7,6 +7,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.LearnTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.util.Callback;
@@ -14,8 +15,8 @@ import org.kordamp.ikonli.Ikon;
 
 public abstract class LearnCategoryPage extends CategoryPageBase<Learn> {
 
-    public LearnCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public LearnCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnJavaFXCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnJavaFXCategoryPage.java
@@ -3,14 +3,15 @@ package com.dlsc.jfxcentral2.app.pages.category;
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class LearnJavaFXCategoryPage extends LearnCategoryPage {
 
-    public LearnJavaFXCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public LearnJavaFXCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnMobileCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnMobileCategoryPage.java
@@ -3,14 +3,15 @@ package com.dlsc.jfxcentral2.app.pages.category;
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class LearnMobileCategoryPage extends LearnCategoryPage {
 
-    public LearnMobileCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public LearnMobileCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
 

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnRaspberryPiCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LearnRaspberryPiCategoryPage.java
@@ -3,14 +3,15 @@ package com.dlsc.jfxcentral2.app.pages.category;
 import com.dlsc.jfxcentral.data.DataRepository;
 import com.dlsc.jfxcentral.data.model.Learn;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class LearnRaspberryPiCategoryPage extends LearnCategoryPage {
 
-    public LearnRaspberryPiCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public LearnRaspberryPiCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
 

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LibrariesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/LibrariesCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.SearchFilterView;
 import com.dlsc.jfxcentral2.components.tiles.LibraryTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class LibrariesCategoryPage extends CategoryPageBase<Library> {
 
-    public LibrariesCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public LibrariesCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/PeopleCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/PeopleCategoryPage.java
@@ -9,6 +9,7 @@ import com.dlsc.jfxcentral2.components.headers.CategoryHeader;
 import com.dlsc.jfxcentral2.components.tiles.PersonTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -23,8 +24,8 @@ public class PeopleCategoryPage extends CategoryPageBase<Person> {
 
     private static final Image BANNER_IMAGE = new Image(Objects.requireNonNull(PeopleCategoryPage.class.getResource("people-banner.jpg")).toExternalForm());
 
-    public PeopleCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public PeopleCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ShowcasesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ShowcasesCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.ShowcaseFilterView;
 import com.dlsc.jfxcentral2.components.tiles.AppTileView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class ShowcasesCategoryPage extends CategoryPageBase<RealWorldApp> {
 
-    public ShowcasesCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public ShowcasesCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TipCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TipCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.TipsAndTricksFilterView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.components.tiles.TipsAndTricksTileView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class TipCategoryPage extends CategoryPageBase<Tip> {
 
-    public TipCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public TipCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ToolsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/ToolsCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.ToolsFilterView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.components.tiles.ToolTileView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class ToolsCategoryPage extends CategoryPageBase<Tool> {
 
-    public ToolsCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public ToolsCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TutorialsCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/TutorialsCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.TutorialsFilterView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.components.tiles.TutorialTileView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class TutorialsCategoryPage extends CategoryPageBase<Tutorial> {
 
-    public TutorialsCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public TutorialsCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/UtilitiesCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/UtilitiesCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.UtilitiesFilterView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.components.tiles.UtilityTileView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
@@ -17,8 +18,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class UtilitiesCategoryPage extends CategoryPageBase<Utility> {
 
-    public UtilitiesCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public UtilitiesCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/VideosCategoryPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/category/VideosCategoryPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.filters.VideosFilterView;
 import com.dlsc.jfxcentral2.components.tiles.TileViewBase;
 import com.dlsc.jfxcentral2.components.tiles.VideoTileView;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import com.dlsc.jfxcentral2.utils.IkonUtil;
 import com.dlsc.jfxcentral2.utils.VideoViewFactory;
 import javafx.beans.property.ObjectProperty;
@@ -19,8 +20,8 @@ import org.kordamp.ikonli.Ikon;
 
 public class VideosCategoryPage extends CategoryPageBase<Video> {
 
-    public VideosCategoryPage(ObjectProperty<Size> size) {
-        super(size);
+    public VideosCategoryPage(ObjectProperty<Size> size, PageRequest pageRequest) {
+        super(size, pageRequest);
     }
 
     @Override

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.gridview.IkonGridView;
 import com.dlsc.jfxcentral2.components.headers.IconDetailHeader;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
+import com.dlsc.jfxcentral2.utils.PageRequest;
 import javafx.beans.property.ObjectProperty;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
@@ -16,8 +17,12 @@ import org.kordamp.ikonli.Ikon;
 
 public class IconPackDetailPage extends DetailsPageBase<IkonliPack> {
 
-    public IconPackDetailPage(ObjectProperty<Size> size, String itemId) {
+    private final PageRequest pageRequest;
+
+    public IconPackDetailPage(ObjectProperty<Size> size, String itemId, PageRequest pageRequest) {
         super(size, IkonliPack.class, itemId);
+
+        this.pageRequest = pageRequest == null ? PageRequest.EMPTY : pageRequest;
 
         // Override: try aggregated pack lookup if DataRepository didn't find the item
         if (getItem() == null) {
@@ -39,6 +44,7 @@ public class IconPackDetailPage extends DetailsPageBase<IkonliPack> {
         // filter view
         IkonliIconsFilter filter = new IkonliIconsFilter();
         filter.sizeProperty().bind(sizeProperty());
+        filter.applyQueryParams(pageRequest.params());
 
         // data (supports both original and aggregated packs)
         FilteredList<Ikon> filteredList = new FilteredList<>(IkonliPackUtil.getInstance().getIkonList(ikonliPack));

--- a/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
+++ b/app/src/main/java/com/dlsc/jfxcentral2/app/pages/details/IconPackDetailPage.java
@@ -45,6 +45,7 @@ public class IconPackDetailPage extends DetailsPageBase<IkonliPack> {
         IkonliIconsFilter filter = new IkonliIconsFilter();
         filter.sizeProperty().bind(sizeProperty());
         filter.applyQueryParams(pageRequest.params());
+        filter.setCanonicalPath(pageRequest.path());
 
         // data (supports both original and aggregated packs)
         FilteredList<Ikon> filteredList = new FilteredList<>(IkonliPackUtil.getInstance().getIkonList(ikonliPack));

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -22,7 +22,6 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
-import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
@@ -44,7 +43,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 public class PacksIconsView extends PaneBase {
@@ -85,7 +83,6 @@ public class PacksIconsView extends PaneBase {
      */
     private String canonicalPath;
     private String lastWrittenUrl;
-    private BiPredicate<Node, String> urlWriter = BrowserUrlSync::replace;
 
     private enum Scope {
         PACKS, ICONS;
@@ -239,16 +236,10 @@ public class PacksIconsView extends PaneBase {
 
     /**
      * Applies the query parameters of the current request: "scope" picks packs or icons, "pack"
-     * narrows the icon scope down to a comma separated list of pack ids, "sort" picks a sort order
-     * and "search" fills the search field.
-     *
-     * <p>The order matters: changing the scope clears the search field and resets the sort order, so
-     * those two have to be applied afterwards. Values that match nothing are ignored.
-     *
-     * <p>"pack" only belongs to the icon scope and is ignored otherwise. Applying it while the pack
-     * scope is active would select packs the icon list does not follow, because that list is only
-     * recomputed while the icon scope is active - and the pack selection is hidden in the pack
-     * scope, so the user could never bring the two back in sync.
+     * narrows the icon scope to a comma separated list of pack ids, "sort" picks a sort order and
+     * "search" fills the search field. The scope is applied first because it clears the search and
+     * resets the sort. The pack parameter only applies to the icon scope; in the pack scope the
+     * selection is hidden and the icon list is not recomputed, so it is ignored there.
      *
      * @param params the parameters of the request, may be {@code null}
      */
@@ -328,9 +319,9 @@ public class PacksIconsView extends PaneBase {
     /**
      * Sets the path the browser address bar is kept in sync with. While it is set, every later change
      * of the scope, the selected packs, the sort order or the search text rewrites the address bar
-     * without reloading the page; {@code null} turns the sync off. The current state is not written
-     * on the call itself, so that mounting the page does not overwrite the history entry the router
-     * is about to push.
+     * without reloading the page; {@code null} turns the sync off. The router pushes the history
+     * entry only after the page is mounted, so writing on this call would replace the previous
+     * page's entry instead.
      *
      * @param canonicalPath the path of the page as registered in the router, or {@code null}
      */
@@ -376,20 +367,12 @@ public class PacksIconsView extends PaneBase {
         return params;
     }
 
-    /**
-     * Replaces the function that writes the URL, so that a local harness can observe the sync
-     * outside of the browser. Null restores the default.
-     */
-    void setUrlWriter(BiPredicate<Node, String> urlWriter) {
-        this.urlWriter = urlWriter == null ? BrowserUrlSync::replace : urlWriter;
-    }
-
     private void writeUrl() {
         if (canonicalPath == null) {
             return;
         }
         String url = QueryParams.buildUrl(canonicalPath, toQueryParams());
-        if (!url.equals(lastWrittenUrl) && urlWriter.test(this, url)) {
+        if (!url.equals(lastWrittenUrl) && BrowserUrlSync.replace(this, url)) {
             lastWrittenUrl = url;
         }
     }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -8,6 +8,7 @@ import com.dlsc.jfxcentral2.components.gridview.ModelGridView;
 import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
 import com.dlsc.jfxcentral2.model.Size;
+import com.dlsc.jfxcentral2.utils.BrowserUrlSync;
 import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
 import com.dlsc.jfxcentral2.utils.QueryParams;
 import javafx.beans.binding.Bindings;
@@ -15,11 +16,13 @@ import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
+import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
@@ -37,8 +40,12 @@ import org.kordamp.ikonli.Ikon;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 public class PacksIconsView extends PaneBase {
 
@@ -60,6 +67,13 @@ public class PacksIconsView extends PaneBase {
      * Suppresses the debounced search while the search text is being set programmatically.
      */
     private boolean applyingQueryParams;
+
+    /**
+     * The path the browser address bar is kept in sync with, null turns the sync off.
+     */
+    private String canonicalPath;
+    private String lastWrittenUrl;
+    private BiPredicate<Node, String> urlWriter = BrowserUrlSync::replace;
 
     private static final String SCOPE_PARAM = "scope";
     private static final String PACK_PARAM = "pack";
@@ -152,6 +166,18 @@ public class PacksIconsView extends PaneBase {
         scopeComboBox.getSelectionModel().selectedItemProperty().addListener((ob, ov, nv) -> {
             searchField.setText("");
             sortComboBox.getSelectionModel().select(0);
+        });
+
+        // The controls are created once, so the listeners can be attached here. The address bar
+        // follows the debounced search text, so it only changes when the filtering does.
+        scopeComboBox.getSelectionModel().selectedItemProperty().addListener(it -> writeUrl());
+        sortComboBox.getSelectionModel().selectedItemProperty().addListener(it -> writeUrl());
+        ikonliPackSelection.getSelectionModel().getSelectedItems().addListener((ListChangeListener<IkonliPack>) change -> writeUrl());
+        searchText.addListener(it -> writeUrl());
+        sceneProperty().addListener((ob, ov, nv) -> {
+            if (nv != null) {
+                writeUrl();
+            }
         });
 
         ObjectBinding<? extends PaneBase> gridViewNodeBinding = Bindings.createObjectBinding(() -> {
@@ -291,6 +317,72 @@ public class PacksIconsView extends PaneBase {
             applyingQueryParams = false;
         }
         searchText.set(text);
+    }
+
+    /**
+     * Sets the path the browser address bar is kept in sync with. While it is set, every change of
+     * the scope, the selected packs, the sort order or the search text rewrites the address bar
+     * without reloading the page; {@code null} turns the sync off.
+     *
+     * @param canonicalPath the path of the page as registered in the router, or {@code null}
+     */
+    public void setCanonicalPath(String canonicalPath) {
+        this.canonicalPath = canonicalPath;
+        writeUrl();
+    }
+
+    /**
+     * The current state as query parameters, omitting every dimension that is at its default. The
+     * packs are only part of it in the icon scope, matching {@link #applyQueryParams(QueryParams)}.
+     *
+     * @return the parameters, never {@code null}
+     */
+    public Map<String, String> toQueryParams() {
+        Map<String, String> params = new LinkedHashMap<>();
+
+        Scope scope = scopeComboBox.getSelectionModel().getSelectedItem();
+        if (scope != null && scope != Scope.ICONS) {
+            params.put(SCOPE_PARAM, scope.paramValue());
+        }
+
+        if (scope == Scope.ICONS) {
+            List<IkonliPack> selected = ikonliPackSelection.getSelectionModel().getSelectedItems();
+            if (!selected.isEmpty() && selected.size() < ikonliPackSelection.getItems().size()) {
+                params.put(PACK_PARAM, selected.stream()
+                        .map(pack -> IkonliPackUtil.getInstance().getAggregatedId(pack))
+                        .collect(Collectors.joining(PACK_SEPARATOR)));
+            }
+        }
+
+        Sort sort = sortComboBox.getSelectionModel().getSelectedItem();
+        if (sort != null && sort != Sort.FROM_A_TO_Z) {
+            params.put(SORT_PARAM, sort.paramValue());
+        }
+
+        String text = searchText.get();
+        if (StringUtils.isNotBlank(text)) {
+            params.put(SEARCH_PARAM, text.trim());
+        }
+
+        return params;
+    }
+
+    /**
+     * Replaces the function that writes the URL, so that a local harness can observe the sync
+     * outside of the browser. Null restores the default.
+     */
+    void setUrlWriter(BiPredicate<Node, String> urlWriter) {
+        this.urlWriter = urlWriter == null ? BrowserUrlSync::replace : urlWriter;
+    }
+
+    private void writeUrl() {
+        if (canonicalPath == null) {
+            return;
+        }
+        String url = QueryParams.buildUrl(canonicalPath, toQueryParams());
+        if (!url.equals(lastWrittenUrl) && urlWriter.test(this, url)) {
+            lastWrittenUrl = url;
+        }
     }
 
     private class SearchService extends Service<String> {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -9,6 +9,7 @@ import com.dlsc.jfxcentral2.components.tiles.IkonliPackTileView;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
 import com.dlsc.jfxcentral2.model.Size;
 import com.dlsc.jfxcentral2.utils.IkonliPackUtil;
+import com.dlsc.jfxcentral2.utils.QueryParams;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.SimpleStringProperty;
@@ -34,7 +35,10 @@ import javafx.util.StringConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.Ikon;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 
 public class PacksIconsView extends PaneBase {
 
@@ -49,13 +53,40 @@ public class PacksIconsView extends PaneBase {
     private final IkonGridView ikonGridView;
     private final ComboBox<Scope> scopeComboBox;
     private final HBox packSelectionWrapper;
+    private final SelectionBox<IkonliPack> ikonliPackSelection;
+    private final ComboBox<Sort> sortComboBox;
+
+    /**
+     * Suppresses the debounced search while the search text is being set programmatically.
+     */
+    private boolean applyingQueryParams;
+
+    private static final String SCOPE_PARAM = "scope";
+    private static final String PACK_PARAM = "pack";
+    private static final String SORT_PARAM = "sort";
+    private static final String SEARCH_PARAM = "search";
+    private static final String PACK_SEPARATOR = ",";
 
     private enum Scope {
-        PACKS, ICONS
+        PACKS, ICONS;
+
+        String paramValue() {
+            return name().toLowerCase(Locale.ROOT);
+        }
     }
 
     private enum Sort {
-        FROM_A_TO_Z, FROM_Z_TO_A
+        FROM_A_TO_Z("az"), FROM_Z_TO_A("za");
+
+        private final String paramValue;
+
+        Sort(String paramValue) {
+            this.paramValue = paramValue;
+        }
+
+        String paramValue() {
+            return paramValue;
+        }
     }
 
     public PacksIconsView() {
@@ -65,7 +96,12 @@ public class PacksIconsView extends PaneBase {
         searchField = new CustomSearchField(true);
         searchField.getStyleClass().add("filter-search-field");
         searchField.setFocusTraversable(false);
-        searchField.textProperty().addListener((ob, ov, str) -> searchService.restart());
+        searchField.textProperty().addListener((ob, ov, str) -> {
+            if (applyingQueryParams) {
+                return;
+            }
+            searchService.restart();
+        });
         HBox.setHgrow(searchField, Priority.ALWAYS);
 
         searchService.setOnSucceeded(evt -> searchText.set(searchField.getText()));
@@ -87,7 +123,7 @@ public class PacksIconsView extends PaneBase {
         }, scopeComboBox.getSelectionModel().selectedItemProperty()));
 
         // pack selection
-        SelectionBox<IkonliPack> ikonliPackSelection = initIkonliPackSelection();
+        ikonliPackSelection = initIkonliPackSelection();
         ikonliPackSelection.getStyleClass().addAll("pack-selection");
         ikonliPackSelection.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(ikonliPackSelection, Priority.ALWAYS);
@@ -97,7 +133,7 @@ public class PacksIconsView extends PaneBase {
         packSelectionWrapper.managedProperty().bind(packSelectionWrapper.visibleProperty());
         packSelectionWrapper.visibleProperty().bind(scopeComboBox.getSelectionModel().selectedItemProperty().map(item -> item == Scope.ICONS));
 
-        ComboBox<Sort> sortComboBox = initSortComboBox();
+        sortComboBox = initSortComboBox();
         sortComboBox.getStyleClass().addAll("sort-combo-box");
         sortComboBox.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(sortComboBox, Priority.ALWAYS);
@@ -172,6 +208,82 @@ public class PacksIconsView extends PaneBase {
         contentBox.getStyleClass().add("content-box");
         getChildren().setAll(contentBox);
         updateUI();
+    }
+
+    /**
+     * Applies the query parameters of the current request: "scope" picks packs or icons, "pack"
+     * narrows the icon scope down to a comma separated list of pack ids, "sort" picks a sort order
+     * and "search" fills the search field.
+     *
+     * <p>The order matters: changing the scope clears the search field and resets the sort order, so
+     * those two have to be applied afterwards. Values that match nothing are ignored.
+     *
+     * @param params the parameters of the request, may be {@code null}
+     */
+    public void applyQueryParams(QueryParams params) {
+        if (params == null || params.isEmpty()) {
+            return;
+        }
+
+        params.get(SCOPE_PARAM).ifPresent(this::applyScope);
+        params.get(PACK_PARAM).ifPresent(this::applyPacks);
+        params.get(SORT_PARAM).ifPresent(this::applySort);
+        params.get(SEARCH_PARAM).ifPresent(this::applySearchText);
+    }
+
+    private void applyScope(String value) {
+        String normalized = QueryParams.normalize(value);
+        for (Scope scope : Scope.values()) {
+            if (QueryParams.normalize(scope.paramValue()).equals(normalized)) {
+                scopeComboBox.getSelectionModel().select(scope);
+                return;
+            }
+        }
+    }
+
+    private void applyPacks(String value) {
+        List<IkonliPack> matches = new ArrayList<>();
+        for (String id : value.split(PACK_SEPARATOR)) {
+            IkonliPack pack = IkonliPackUtil.getInstance().getAggregatedPack(id.trim());
+            if (pack != null && !matches.contains(pack)) {
+                matches.add(pack);
+            }
+        }
+
+        // An empty selection would show nothing at all, so an unusable parameter falls back to the
+        // default of having every pack selected.
+        if (matches.isEmpty()) {
+            ikonliPackSelection.getSelectionModel().selectAll();
+            return;
+        }
+
+        ikonliPackSelection.getSelectionModel().clearSelection();
+        for (IkonliPack pack : matches) {
+            ikonliPackSelection.getSelectionModel().select(pack);
+        }
+    }
+
+    private void applySort(String value) {
+        String normalized = QueryParams.normalize(value);
+        for (Sort sort : Sort.values()) {
+            if (QueryParams.normalize(sort.paramValue()).equals(normalized)) {
+                sortComboBox.getSelectionModel().select(sort);
+                return;
+            }
+        }
+    }
+
+    private void applySearchText(String text) {
+        // Setting the text starts the debounced search service, which would only delay the first
+        // filtering. The grid switches on the raw text, the filtering on the debounced one, so both
+        // have to be set here.
+        applyingQueryParams = true;
+        try {
+            searchField.setText(text);
+        } finally {
+            applyingQueryParams = false;
+        }
+        searchText.set(text);
     }
 
     private class SearchService extends Service<String> {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -180,11 +180,6 @@ public class PacksIconsView extends PaneBase {
         sortComboBox.getSelectionModel().selectedItemProperty().addListener(it -> writeUrl());
         ikonliPackSelection.getSelectionModel().getSelectedItems().addListener((ListChangeListener<IkonliPack>) change -> writeUrl());
         searchText.addListener(it -> writeUrl());
-        sceneProperty().addListener((ob, ov, nv) -> {
-            if (nv != null) {
-                writeUrl();
-            }
-        });
 
         ObjectBinding<? extends PaneBase> gridViewNodeBinding = Bindings.createObjectBinding(() -> {
             if (StringUtils.isBlank(searchField.getText()) || (scopeComboBox.getSelectionModel().getSelectedItem() == Scope.PACKS)) {
@@ -331,15 +326,16 @@ public class PacksIconsView extends PaneBase {
     }
 
     /**
-     * Sets the path the browser address bar is kept in sync with. While it is set, every change of
-     * the scope, the selected packs, the sort order or the search text rewrites the address bar
-     * without reloading the page; {@code null} turns the sync off.
+     * Sets the path the browser address bar is kept in sync with. While it is set, every later change
+     * of the scope, the selected packs, the sort order or the search text rewrites the address bar
+     * without reloading the page; {@code null} turns the sync off. The current state is not written
+     * on the call itself, so that mounting the page does not overwrite the history entry the router
+     * is about to push.
      *
      * @param canonicalPath the path of the page as registered in the router, or {@code null}
      */
     public void setCanonicalPath(String canonicalPath) {
         this.canonicalPath = canonicalPath;
-        writeUrl();
     }
 
     /**

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -81,6 +81,12 @@ public class PacksIconsView extends PaneBase {
     private static final String SEARCH_PARAM = "search";
     private static final String PACK_SEPARATOR = ",";
 
+    /**
+     * Stable value for "no pack selected", so that an empty selection round trips instead of being
+     * indistinguishable from "every pack selected", which also omits the parameter.
+     */
+    private static final String PACK_NONE = "none";
+
     private enum Scope {
         PACKS, ICONS;
 
@@ -275,6 +281,11 @@ public class PacksIconsView extends PaneBase {
     }
 
     private void applyPacks(String value) {
+        if (PACK_NONE.equals(QueryParams.normalize(value))) {
+            ikonliPackSelection.getSelectionModel().clearSelection();
+            return;
+        }
+
         List<IkonliPack> matches = new ArrayList<>();
         for (String id : value.split(PACK_SEPARATOR)) {
             IkonliPack pack = IkonliPackUtil.getInstance().getAggregatedPack(id.trim());
@@ -347,7 +358,9 @@ public class PacksIconsView extends PaneBase {
 
         if (scope == Scope.ICONS) {
             List<IkonliPack> selected = ikonliPackSelection.getSelectionModel().getSelectedItems();
-            if (!selected.isEmpty() && selected.size() < ikonliPackSelection.getItems().size()) {
+            if (selected.isEmpty()) {
+                params.put(PACK_PARAM, PACK_NONE);
+            } else if (selected.size() < ikonliPackSelection.getItems().size()) {
                 params.put(PACK_PARAM, selected.stream()
                         .map(pack -> IkonliPackUtil.getInstance().getAggregatedId(pack))
                         .collect(Collectors.joining(PACK_SEPARATOR)));

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -51,6 +51,18 @@ public class PacksIconsView extends PaneBase {
 
     private static final int SEARCH_DELAY = 200;
 
+    private static final String SCOPE_PARAM = "scope";
+    private static final String PACK_PARAM = "pack";
+    private static final String SORT_PARAM = "sort";
+    private static final String SEARCH_PARAM = "search";
+    private static final String PACK_SEPARATOR = ",";
+
+    /**
+     * Stable value for "no pack selected", so that an empty selection round trips instead of being
+     * indistinguishable from "every pack selected", which also omits the parameter.
+     */
+    private static final String PACK_NONE = "none";
+
     private final CustomSearchField searchField;
     private final StackPane topWrapper;
     private final HBox sortComboBoxWrapper;
@@ -74,18 +86,6 @@ public class PacksIconsView extends PaneBase {
     private String canonicalPath;
     private String lastWrittenUrl;
     private BiPredicate<Node, String> urlWriter = BrowserUrlSync::replace;
-
-    private static final String SCOPE_PARAM = "scope";
-    private static final String PACK_PARAM = "pack";
-    private static final String SORT_PARAM = "sort";
-    private static final String SEARCH_PARAM = "search";
-    private static final String PACK_SEPARATOR = ",";
-
-    /**
-     * Stable value for "no pack selected", so that an empty selection round trips instead of being
-     * indistinguishable from "every pack selected", which also omits the parameter.
-     */
-    private static final String PACK_NONE = "none";
 
     private enum Scope {
         PACKS, ICONS;
@@ -283,7 +283,7 @@ public class PacksIconsView extends PaneBase {
 
         List<IkonliPack> matches = new ArrayList<>();
         for (String id : value.split(PACK_SEPARATOR)) {
-            IkonliPack pack = IkonliPackUtil.getInstance().getAggregatedPack(id.trim());
+            IkonliPack pack = IkonliPackUtil.getInstance().getAggregatedPack(id.trim().toLowerCase(Locale.ROOT));
             if (pack != null && !matches.contains(pack)) {
                 matches.add(pack);
             }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/PacksIconsView.java
@@ -218,6 +218,11 @@ public class PacksIconsView extends PaneBase {
      * <p>The order matters: changing the scope clears the search field and resets the sort order, so
      * those two have to be applied afterwards. Values that match nothing are ignored.
      *
+     * <p>"pack" only belongs to the icon scope and is ignored otherwise. Applying it while the pack
+     * scope is active would select packs the icon list does not follow, because that list is only
+     * recomputed while the icon scope is active - and the pack selection is hidden in the pack
+     * scope, so the user could never bring the two back in sync.
+     *
      * @param params the parameters of the request, may be {@code null}
      */
     public void applyQueryParams(QueryParams params) {
@@ -226,7 +231,9 @@ public class PacksIconsView extends PaneBase {
         }
 
         params.get(SCOPE_PARAM).ifPresent(this::applyScope);
-        params.get(PACK_PARAM).ifPresent(this::applyPacks);
+        if (scopeComboBox.getSelectionModel().getSelectedItem() == Scope.ICONS) {
+            params.get(PACK_PARAM).ifPresent(this::applyPacks);
+        }
         params.get(SORT_PARAM).ifPresent(this::applySort);
         params.get(SEARCH_PARAM).ifPresent(this::applySearchText);
     }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/DocumentationFilterView.java
@@ -20,8 +20,8 @@ public class DocumentationFilterView extends SimpleSearchFilterView<Documentatio
 
         //Documentation are still displayed in alphabetical order.
         setSortGroup(new SortGroup<>("ORDER", List.of(
-                new SortItem<>("From A to Z", Comparator.comparing((Documentation modelObject) -> modelObject.getName().toLowerCase())),
-                new SortItem<>("From Z to A", Comparator.comparing((Documentation modelObject) -> modelObject.getName().toLowerCase()).reversed()))
+                new SortItem<>("From A to Z", Comparator.comparing((Documentation modelObject) -> modelObject.getName().toLowerCase()), "az"),
+                new SortItem<>("From Z to A", Comparator.comparing((Documentation modelObject) -> modelObject.getName().toLowerCase()).reversed(), "za"))
         ));
 
         setSearchPromptText("Search for documentation ...");

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/IkonliIconsFilter.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/IkonliIconsFilter.java
@@ -16,8 +16,8 @@ public class IkonliIconsFilter extends SimpleSearchFilterView<Ikon> {
         setSearchPromptText("Search by name");
 
         setSortGroup(new SortGroup<>("ORDER", List.of(
-                new SortItem<>("From A to Z", Comparator.comparing((Ikon ikon) -> ikon.getDescription().toLowerCase())),
-                new SortItem<>("From Z to A", Comparator.comparing((Ikon ikon) -> ikon.getDescription().toLowerCase()).reversed()))
+                new SortItem<>("From A to Z", Comparator.comparing((Ikon ikon) -> ikon.getDescription().toLowerCase()), "az"),
+                new SortItem<>("From Z to A", Comparator.comparing((Ikon ikon) -> ikon.getDescription().toLowerCase()).reversed(), "za"))
         ));
 
         setOnSearch(text -> icon -> StringUtils.isBlank(text) || StringUtils.containsIgnoreCase(icon.getDescription(), text));

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/LearnFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/LearnFilterView.java
@@ -34,9 +34,9 @@ public class LearnFilterView extends SimpleModelObjectSearchFilterView<Learn> {
                         return piList.indexOf(pi);
                     }
                     return 0;
-                })),
-                new SortItem<>("From A to Z", Comparator.comparing((Learn modelObject) -> modelObject.getName().toLowerCase())),
-                new SortItem<>("From Z to A", Comparator.comparing((Learn modelObject) -> modelObject.getName().toLowerCase()).reversed()))
+                }), "natural"),
+                new SortItem<>("From A to Z", Comparator.comparing((Learn modelObject) -> modelObject.getName().toLowerCase()), "az"),
+                new SortItem<>("From Z to A", Comparator.comparing((Learn modelObject) -> modelObject.getName().toLowerCase()).reversed(), "za"))
         ));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
@@ -194,11 +194,6 @@ public class SearchFilterView<T> extends PaneBase {
 
         // The address bar follows the debounced text, so it only changes when the filtering does.
         searchText.addListener(it -> writeUrl());
-        sceneProperty().addListener((ob, ov, nv) -> {
-            if (nv != null) {
-                writeUrl();
-            }
-        });
 
         filterBoxOrientationProperty().addListener(it -> layoutBySize());
         filterGroupsProperty().addListener((InvalidationListener) it -> layoutBySize());
@@ -291,15 +286,15 @@ public class SearchFilterView<T> extends PaneBase {
     }
 
     /**
-     * Sets the path the browser address bar is kept in sync with. While it is set, every change of
-     * the search text, a filter or the sort order rewrites the address bar without reloading the
-     * page; {@code null} turns the sync off.
+     * Sets the path the browser address bar is kept in sync with. While it is set, every later change
+     * of the search text, a filter or the sort order rewrites the address bar without reloading the
+     * page; {@code null} turns the sync off. The current state is not written on the call itself, so
+     * that mounting the page does not overwrite the history entry the router is about to push.
      *
      * @param canonicalPath the path of the page as registered in the router, or {@code null}
      */
     public void setCanonicalPath(String canonicalPath) {
         this.canonicalPath = canonicalPath;
-        writeUrl();
     }
 
     /**

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
@@ -5,6 +5,7 @@ import com.dlsc.jfxcentral2.components.CustomSearchField;
 import com.dlsc.jfxcentral2.components.Header;
 import com.dlsc.jfxcentral2.components.PaneBase;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
+import com.dlsc.jfxcentral2.utils.QueryParams;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
@@ -44,7 +45,9 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -57,6 +60,12 @@ public class SearchFilterView<T> extends PaneBase {
     private static final String DEFAULT_STYLE_CLASS = "search-filter-view";
     private static final Orientation FILTER_BOX_DEFAULT_ORIENTATION = Orientation.HORIZONTAL;
     private static final String WITH_SEARCH_FIELD = "with-search-field";
+
+    /**
+     * Reserved query parameter names, see {@link #applyQueryParams(QueryParams)}.
+     */
+    private static final String SEARCH_PARAM = "search";
+    private static final String SORT_PARAM = "sort";
 
     /**
      * delayed search interval 200 ms
@@ -77,6 +86,27 @@ public class SearchFilterView<T> extends PaneBase {
 
     private ScheduledFuture<?> future;
     private final CustomSearchField searchField = new CustomSearchField(true);
+
+    /**
+     * The current selection per filter group, keyed by parameter name. The combo boxes are recreated
+     * on every layout change, so the selection has to survive outside of them. The applied flag of
+     * the filter items must not be used for this: those lists are static and shared by all sessions.
+     */
+    private final Map<String, String> selectedFilterNames = new LinkedHashMap<>();
+    private String selectedSortParamValue;
+
+    /**
+     * The combo boxes of the current layout, so that query parameters take effect immediately
+     * instead of only after the next rebuild.
+     */
+    private final Map<String, ComboBox<FilterItem<T>>> comboBoxByParam = new LinkedHashMap<>();
+    private ComboBox<SortItem<T>> sortComboBox;
+
+    /**
+     * Suppresses the debounced search while the search text is being set programmatically.
+     */
+    private boolean applyingQueryParams;
+
     private final StringConverter<FilterItem<T>> predicateItemStringConverter = new StringConverter<>() {
         @Override
         public String toString(FilterItem<T> object) {
@@ -95,12 +125,35 @@ public class SearchFilterView<T> extends PaneBase {
         }
     }
 
-    public record FilterGroup<T>(String title, List<FilterItem<T>> filterItems) {
+    /**
+     * A group of mutually exclusive filters, rendered as a single combo box.
+     *
+     * @param paramName the query parameter this group is addressed by, derived from the title
+     */
+    public record FilterGroup<T>(String title, List<FilterItem<T>> filterItems, String paramName) {
+        public FilterGroup(String title, List<FilterItem<T>> filterItems) {
+            this(title, filterItems, QueryParams.toSlug(title));
+        }
     }
 
-    public record SortItem<T>(String name, Comparator<T> comparator, boolean isApplied) {
+    /**
+     * A sort order offered by a {@link SortGroup}.
+     *
+     * @param paramValue the stable value used in the "sort" query parameter. It is deliberately not
+     *                   derived from the display name, so that rewording a label does not break
+     *                   links that were already shared.
+     */
+    public record SortItem<T>(String name, Comparator<T> comparator, boolean isApplied, String paramValue) {
         public SortItem(String name, Comparator<T> comparator) {
-            this(name, comparator, false);
+            this(name, comparator, false, QueryParams.toSlug(name));
+        }
+
+        public SortItem(String name, Comparator<T> comparator, String paramValue) {
+            this(name, comparator, false, paramValue);
+        }
+
+        public SortItem(String name, Comparator<T> comparator, boolean isApplied) {
+            this(name, comparator, isApplied, QueryParams.toSlug(name));
         }
     }
 
@@ -116,6 +169,9 @@ public class SearchFilterView<T> extends PaneBase {
         searchField.managedProperty().bind(searchField.visibleProperty());
         searchField.visibleProperty().bind(onSearchProperty().isNotNull());
         searchField.textProperty().addListener((ob, ov, str) -> {
+            if (applyingQueryParams) {
+                return;
+            }
             if (future != null) {
                 future.cancel(false);
             }
@@ -143,6 +199,77 @@ public class SearchFilterView<T> extends PaneBase {
 
         layoutBySize();
 
+    }
+
+    /**
+     * Applies the query parameters of the current request: "search" fills the search field, "sort"
+     * picks a sort order and every filter group is addressed by its own parameter name.
+     *
+     * <p>A value that matches no item is ignored and the group falls back to its default, so that a
+     * shared link keeps working after the underlying data has been renamed.
+     *
+     * @param params the parameters of the request, may be {@code null}
+     */
+    public void applyQueryParams(QueryParams params) {
+        if (params == null || params.isEmpty()) {
+            return;
+        }
+
+        params.get(SEARCH_PARAM).ifPresent(this::applySearchText);
+
+        for (FilterGroup<T> filterGroup : getFilterGroups()) {
+            params.get(filterGroup.paramName()).ifPresent(value -> applyFilterValue(filterGroup, value));
+        }
+
+        SortGroup<T> sortGroup = getSortGroup();
+        if (sortGroup != null) {
+            params.get(SORT_PARAM).ifPresent(value -> applySortValue(sortGroup, value));
+        }
+    }
+
+    private void applySearchText(String text) {
+        // Setting the text triggers the debounced search, which would both delay the first filtering
+        // and spin up this instance's scheduler thread for a user who never typed anything.
+        applyingQueryParams = true;
+        try {
+            searchField.setText(text);
+        } finally {
+            applyingQueryParams = false;
+        }
+        searchText.set(text);
+    }
+
+    private void applyFilterValue(FilterGroup<T> filterGroup, String value) {
+        String normalized = QueryParams.normalize(value);
+        FilterItem<T> item = findFilterItem(filterGroup, it -> QueryParams.normalize(it.name()).equals(normalized));
+        if (item == null) {
+            item = defaultItem(filterGroup);
+        }
+        if (item == null) {
+            return;
+        }
+
+        selectedFilterNames.put(filterGroup.paramName(), item.name());
+        ComboBox<FilterItem<T>> comboBox = comboBoxByParam.get(filterGroup.paramName());
+        if (comboBox != null) {
+            comboBox.getSelectionModel().select(item);
+        }
+    }
+
+    private void applySortValue(SortGroup<T> sortGroup, String value) {
+        String normalized = QueryParams.normalize(value);
+        SortItem<T> item = findSortItem(sortGroup, it -> QueryParams.normalize(it.paramValue()).equals(normalized));
+        if (item == null) {
+            item = defaultSortItem(sortGroup);
+        }
+        if (item == null) {
+            return;
+        }
+
+        selectedSortParamValue = item.paramValue();
+        if (sortComboBox != null) {
+            sortComboBox.getSelectionModel().select(item);
+        }
     }
 
     private final ReadOnlyObjectWrapper<Predicate<T>> predicate = new ReadOnlyObjectWrapper<>(this, "predicate", item -> true);
@@ -221,6 +348,9 @@ public class SearchFilterView<T> extends PaneBase {
         }
         setPredicate(item -> true);
 
+        comboBoxByParam.clear();
+        sortComboBox = null;
+
         Pane filtersBox = isSmall() ? new VBox() : new HBox();
         filtersBox.getStyleClass().add("filters-box");
         ObservableList<FilterGroup<T>> items = getFilterGroups();
@@ -254,9 +384,9 @@ public class SearchFilterView<T> extends PaneBase {
             if (comparator.isBound()) {
                 comparator.unbind();
             }
-            ComboBox<SortItem<T>> sortComboBox = createComboBox();
-            sortComboBox.getStyleClass().addAll("filter-combo-box", "sort-combo-box");
-            sortComboBox.setConverter(new StringConverter<>() {
+            ComboBox<SortItem<T>> sortBox = createComboBox();
+            sortBox.getStyleClass().addAll("filter-combo-box", "sort-combo-box");
+            sortBox.setConverter(new StringConverter<>() {
                 @Override
                 public String toString(SortItem<T> object) {
                     return object == null ? null : object.name();
@@ -267,13 +397,15 @@ public class SearchFilterView<T> extends PaneBase {
                     return null;
                 }
             });
-            sortComboBox.getItems().setAll(getSortGroup().sortItems());
-            comparator.bind(sortComboBox.getSelectionModel().selectedItemProperty().map(SortItem::comparator));
-            getSortGroup().sortItems().stream().filter(it -> it.isApplied).findFirst()
-                    .ifPresentOrElse(
-                            it -> sortComboBox.getSelectionModel().select(it),
-                            () -> sortComboBox.getSelectionModel().selectFirst()
-                    );
+            sortBox.getItems().setAll(getSortGroup().sortItems());
+            comparator.bind(sortBox.getSelectionModel().selectedItemProperty().map(SortItem::comparator));
+            selectSortItem(sortBox, getSortGroup());
+            sortBox.getSelectionModel().selectedItemProperty().addListener((ob, ov, nv) -> {
+                if (nv != null) {
+                    selectedSortParamValue = nv.paramValue();
+                }
+            });
+            sortComboBox = sortBox;
 
             Pane box = getFilterBoxOrientation() == Orientation.VERTICAL ? new VBox() : new HBox();
             box.getStyleClass().addAll("filter-box", "sort-box");
@@ -281,12 +413,12 @@ public class SearchFilterView<T> extends PaneBase {
             Label titleLabel = new Label(getSortGroup().title);
             titleLabel.setMinWidth(Region.USE_PREF_SIZE);
             titleLabel.getStyleClass().add("filter-title");
-            HBox.setHgrow(sortComboBox, Priority.ALWAYS);
-            sortComboBox.setMaxWidth(Double.MAX_VALUE);
+            HBox.setHgrow(sortBox, Priority.ALWAYS);
+            sortBox.setMaxWidth(Double.MAX_VALUE);
             if (isSmall()) {
-                box.getChildren().setAll(titleLabel, new Spacer(), sortComboBox);
+                box.getChildren().setAll(titleLabel, new Spacer(), sortBox);
             } else {
-                box.getChildren().setAll(titleLabel, sortComboBox);
+                box.getChildren().setAll(titleLabel, sortBox);
             }
             filtersBox.getChildren().add(box);
         }
@@ -321,12 +453,90 @@ public class SearchFilterView<T> extends PaneBase {
         comboBox.getItems().addAll(filterGroup.filterItems);
 
         childPredicateProperty.bind(comboBox.getSelectionModel().selectedItemProperty().map(it -> it == null ? item -> true : it.predicate));
-        filterGroup.filterItems.stream()
-                .filter(FilterItem::isApplied).findFirst()
-                .ifPresentOrElse(it -> comboBox.getSelectionModel().select(it), () -> comboBox.getSelectionModel().selectFirst());
+        selectFilterItem(comboBox, filterGroup);
+        comboBox.getSelectionModel().selectedItemProperty().addListener((ob, ov, nv) -> {
+            if (nv != null) {
+                selectedFilterNames.put(filterGroup.paramName(), nv.name());
+            }
+        });
+        comboBoxByParam.put(filterGroup.paramName(), comboBox);
         comboBox.setMaxWidth(Double.MAX_VALUE);
         HBox.setHgrow(comboBox, Priority.ALWAYS);
         return comboBox;
+    }
+
+    /**
+     * Selects the item a rebuilt combo box has to show: the one selected before, otherwise the
+     * default of the group.
+     */
+    private void selectFilterItem(ComboBox<FilterItem<T>> comboBox, FilterGroup<T> filterGroup) {
+        String selectedName = selectedFilterNames.get(filterGroup.paramName());
+        FilterItem<T> item = null;
+        if (selectedName != null) {
+            item = findFilterItem(filterGroup, it -> selectedName.equals(it.name()));
+        }
+        if (item == null) {
+            item = defaultItem(filterGroup);
+        }
+        if (item == null) {
+            comboBox.getSelectionModel().selectFirst();
+        } else {
+            comboBox.getSelectionModel().select(item);
+        }
+    }
+
+    private void selectSortItem(ComboBox<SortItem<T>> comboBox, SortGroup<T> sortGroup) {
+        SortItem<T> item = null;
+        if (selectedSortParamValue != null) {
+            item = findSortItem(sortGroup, it -> selectedSortParamValue.equals(it.paramValue()));
+        }
+        if (item == null) {
+            item = defaultSortItem(sortGroup);
+        }
+        if (item == null) {
+            comboBox.getSelectionModel().selectFirst();
+        } else {
+            comboBox.getSelectionModel().select(item);
+        }
+    }
+
+    /**
+     * The item a group falls back to: the first one flagged as applied, otherwise the first one.
+     * This is the single definition of "default", shared by the initial selection, the fallback for
+     * an unknown query parameter value and the decision whether a parameter can be omitted.
+     */
+    private FilterItem<T> defaultItem(FilterGroup<T> filterGroup) {
+        List<FilterItem<T>> items = filterGroup.filterItems();
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        FilterItem<T> applied = findFilterItem(filterGroup, FilterItem::isApplied);
+        return applied == null ? items.get(0) : applied;
+    }
+
+    private SortItem<T> defaultSortItem(SortGroup<T> sortGroup) {
+        List<SortItem<T>> items = sortGroup.sortItems();
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        SortItem<T> applied = findSortItem(sortGroup, SortItem::isApplied);
+        return applied == null ? items.get(0) : applied;
+    }
+
+    private FilterItem<T> findFilterItem(FilterGroup<T> filterGroup, Predicate<FilterItem<T>> matcher) {
+        List<FilterItem<T>> items = filterGroup.filterItems();
+        if (items == null) {
+            return null;
+        }
+        return items.stream().filter(matcher).findFirst().orElse(null);
+    }
+
+    private SortItem<T> findSortItem(SortGroup<T> sortGroup, Predicate<SortItem<T>> matcher) {
+        List<SortItem<T>> items = sortGroup.sortItems();
+        if (items == null) {
+            return null;
+        }
+        return items.stream().filter(matcher).findFirst().orElse(null);
     }
 
     private <S> ComboBox<S> createComboBox() {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
@@ -5,6 +5,7 @@ import com.dlsc.jfxcentral2.components.CustomSearchField;
 import com.dlsc.jfxcentral2.components.Header;
 import com.dlsc.jfxcentral2.components.PaneBase;
 import com.dlsc.jfxcentral2.iconfont.JFXCentralIcon;
+import com.dlsc.jfxcentral2.utils.BrowserUrlSync;
 import com.dlsc.jfxcentral2.utils.QueryParams;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -52,6 +53,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -106,6 +108,14 @@ public class SearchFilterView<T> extends PaneBase {
      * Suppresses the debounced search while the search text is being set programmatically.
      */
     private boolean applyingQueryParams;
+
+    /**
+     * The path the browser address bar is kept in sync with. Null turns the sync off, which is the
+     * case for pages that were not created by a registered route.
+     */
+    private String canonicalPath;
+    private String lastWrittenUrl;
+    private BiPredicate<Node, String> urlWriter = BrowserUrlSync::replace;
 
     private final StringConverter<FilterItem<T>> predicateItemStringConverter = new StringConverter<>() {
         @Override
@@ -180,6 +190,14 @@ public class SearchFilterView<T> extends PaneBase {
                     Platform.runLater(() -> searchText.set(str));
                 }
             }, SEARCH_DELAY, TimeUnit.MILLISECONDS);
+        });
+
+        // The address bar follows the debounced text, so it only changes when the filtering does.
+        searchText.addListener(it -> writeUrl());
+        sceneProperty().addListener((ob, ov, nv) -> {
+            if (nv != null) {
+                writeUrl();
+            }
         });
 
         filterBoxOrientationProperty().addListener(it -> layoutBySize());
@@ -269,6 +287,71 @@ public class SearchFilterView<T> extends PaneBase {
         selectedSortParamValue = item.paramValue();
         if (sortComboBox != null) {
             sortComboBox.getSelectionModel().select(item);
+        }
+    }
+
+    /**
+     * Sets the path the browser address bar is kept in sync with. While it is set, every change of
+     * the search text, a filter or the sort order rewrites the address bar without reloading the
+     * page; {@code null} turns the sync off.
+     *
+     * @param canonicalPath the path of the page as registered in the router, or {@code null}
+     */
+    public void setCanonicalPath(String canonicalPath) {
+        this.canonicalPath = canonicalPath;
+        writeUrl();
+    }
+
+    /**
+     * The current state as query parameters, omitting every dimension that is at its default. The
+     * search component is the debounced text, so the result only changes when the filtering does.
+     *
+     * @return the parameters, never {@code null}
+     */
+    public Map<String, String> toQueryParams() {
+        Map<String, String> params = new LinkedHashMap<>();
+
+        if (getOnSearch() != null) {
+            String text = searchText.get();
+            if (StringUtils.isNotBlank(text)) {
+                params.put(SEARCH_PARAM, text.trim());
+            }
+        }
+
+        for (FilterGroup<T> filterGroup : getFilterGroups()) {
+            String selectedName = selectedFilterNames.get(filterGroup.paramName());
+            FilterItem<T> defaultItem = defaultItem(filterGroup);
+            if (selectedName != null && (defaultItem == null || !selectedName.equals(defaultItem.name()))) {
+                params.put(filterGroup.paramName(), QueryParams.toSlug(selectedName));
+            }
+        }
+
+        SortGroup<T> sortGroup = getSortGroup();
+        if (sortGroup != null && selectedSortParamValue != null) {
+            SortItem<T> defaultSortItem = defaultSortItem(sortGroup);
+            if (defaultSortItem == null || !selectedSortParamValue.equals(defaultSortItem.paramValue())) {
+                params.put(SORT_PARAM, selectedSortParamValue);
+            }
+        }
+
+        return params;
+    }
+
+    /**
+     * Replaces the function that writes the URL, so that a local harness can observe the sync
+     * outside of the browser. Null restores the default.
+     */
+    void setUrlWriter(BiPredicate<Node, String> urlWriter) {
+        this.urlWriter = urlWriter == null ? BrowserUrlSync::replace : urlWriter;
+    }
+
+    private void writeUrl() {
+        if (canonicalPath == null) {
+            return;
+        }
+        String url = QueryParams.buildUrl(canonicalPath, toQueryParams());
+        if (!url.equals(lastWrittenUrl) && urlWriter.test(this, url)) {
+            lastWrittenUrl = url;
         }
     }
 
@@ -403,6 +486,7 @@ public class SearchFilterView<T> extends PaneBase {
             sortBox.getSelectionModel().selectedItemProperty().addListener((ob, ov, nv) -> {
                 if (nv != null) {
                     selectedSortParamValue = nv.paramValue();
+                    writeUrl();
                 }
             });
             sortComboBox = sortBox;
@@ -457,6 +541,7 @@ public class SearchFilterView<T> extends PaneBase {
         comboBox.getSelectionModel().selectedItemProperty().addListener((ob, ov, nv) -> {
             if (nv != null) {
                 selectedFilterNames.put(filterGroup.paramName(), nv.name());
+                writeUrl();
             }
         });
         comboBoxByParam.put(filterGroup.paramName(), comboBox);

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SearchFilterView.java
@@ -53,7 +53,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -92,7 +91,7 @@ public class SearchFilterView<T> extends PaneBase {
     /**
      * The current selection per filter group, keyed by parameter name. The combo boxes are recreated
      * on every layout change, so the selection has to survive outside of them. The applied flag of
-     * the filter items must not be used for this: those lists are static and shared by all sessions.
+     * the filter items cannot hold it: those lists are static and shared by all sessions.
      */
     private final Map<String, String> selectedFilterNames = new LinkedHashMap<>();
     private String selectedSortParamValue;
@@ -115,7 +114,6 @@ public class SearchFilterView<T> extends PaneBase {
      */
     private String canonicalPath;
     private String lastWrittenUrl;
-    private BiPredicate<Node, String> urlWriter = BrowserUrlSync::replace;
 
     private final StringConverter<FilterItem<T>> predicateItemStringConverter = new StringConverter<>() {
         @Override
@@ -288,8 +286,8 @@ public class SearchFilterView<T> extends PaneBase {
     /**
      * Sets the path the browser address bar is kept in sync with. While it is set, every later change
      * of the search text, a filter or the sort order rewrites the address bar without reloading the
-     * page; {@code null} turns the sync off. The current state is not written on the call itself, so
-     * that mounting the page does not overwrite the history entry the router is about to push.
+     * page; {@code null} turns the sync off. The router pushes the history entry only after the page
+     * is mounted, so writing on this call would replace the previous page's entry instead.
      *
      * @param canonicalPath the path of the page as registered in the router, or {@code null}
      */
@@ -332,20 +330,12 @@ public class SearchFilterView<T> extends PaneBase {
         return params;
     }
 
-    /**
-     * Replaces the function that writes the URL, so that a local harness can observe the sync
-     * outside of the browser. Null restores the default.
-     */
-    void setUrlWriter(BiPredicate<Node, String> urlWriter) {
-        this.urlWriter = urlWriter == null ? BrowserUrlSync::replace : urlWriter;
-    }
-
     private void writeUrl() {
         if (canonicalPath == null) {
             return;
         }
         String url = QueryParams.buildUrl(canonicalPath, toQueryParams());
-        if (!url.equals(lastWrittenUrl) && urlWriter.test(this, url)) {
+        if (!url.equals(lastWrittenUrl) && BrowserUrlSync.replace(this, url)) {
             lastWrittenUrl = url;
         }
     }
@@ -582,8 +572,8 @@ public class SearchFilterView<T> extends PaneBase {
 
     /**
      * The item a group falls back to: the first one flagged as applied, otherwise the first one.
-     * This is the single definition of "default", shared by the initial selection, the fallback for
-     * an unknown query parameter value and the decision whether a parameter can be omitted.
+     * Used for the initial selection, as the fallback for an unknown parameter value and to decide
+     * whether a parameter can be omitted.
      */
     private FilterItem<T> defaultItem(FilterGroup<T> filterGroup) {
         List<FilterItem<T>> items = filterGroup.filterItems();

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SimpleModelObjectSearchFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/SimpleModelObjectSearchFilterView.java
@@ -9,9 +9,9 @@ public class SimpleModelObjectSearchFilterView<T extends ModelObject> extends Si
 
     public final SortGroup<T> MODEL_DEFAULT_SORT_GROUP = new SortGroup<>("ORDER",
             List.of(
-                    new SortItem<>("Random", Comparator.comparingInt((T modelObject) -> (int) (Math.random() * 1000))),
-                    new SortItem<>("From A to Z", Comparator.comparing((T modelObject) -> modelObject.getName().toLowerCase())),
-                    new SortItem<>("From Z to A", Comparator.comparing((T modelObject) -> modelObject.getName().toLowerCase()).reversed())
+                    new SortItem<>("Random", Comparator.comparingInt((T modelObject) -> (int) (Math.random() * 1000)), "random"),
+                    new SortItem<>("From A to Z", Comparator.comparing((T modelObject) -> modelObject.getName().toLowerCase()), "az"),
+                    new SortItem<>("From Z to A", Comparator.comparing((T modelObject) -> modelObject.getName().toLowerCase()).reversed(), "za")
             ));
 
     public SimpleModelObjectSearchFilterView() {

--- a/components/src/main/java/com/dlsc/jfxcentral2/components/filters/UtilitiesFilterView.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/components/filters/UtilitiesFilterView.java
@@ -15,9 +15,9 @@ public class UtilitiesFilterView extends SimpleModelObjectSearchFilterView<Utili
 
         setSortGroup(new SortGroup<>("ORDER",
                 List.of(
-                        new SortItem<>("Status", Comparator.comparing((Utility modelObject) -> modelObject.getStatus().ordinal())),
-                        new SortItem<>("From A to Z", Comparator.comparing((Utility modelObject) -> modelObject.getName().toLowerCase())),
-                        new SortItem<>("From Z to A", Comparator.comparing((Utility modelObject) -> modelObject.getName().toLowerCase()).reversed())
+                        new SortItem<>("Status", Comparator.comparing((Utility modelObject) -> modelObject.getStatus().ordinal()), "status"),
+                        new SortItem<>("From A to Z", Comparator.comparing((Utility modelObject) -> modelObject.getName().toLowerCase()), "az"),
+                        new SortItem<>("From Z to A", Comparator.comparing((Utility modelObject) -> modelObject.getName().toLowerCase()).reversed(), "za")
                 )
         ));
 

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
@@ -44,8 +44,8 @@ public final class BrowserUrlSync {
             LOGGER.warning("Refusing to write an unexpected URL to the address bar: " + url);
             return false;
         }
-        if (!(SessionManagerContext.getContext(node) instanceof SessionManager sessionManager)
-                || sessionManager.getURL() == null) {
+        SessionManager sessionManager = sessionManagerOf(node);
+        if (sessionManager == null || sessionManager.getURL() == null) {
             return false;
         }
         // The router keeps an absolute URL, so the path has to be resolved against it.
@@ -54,6 +54,22 @@ public final class BrowserUrlSync {
         // Scala setter of the router's url var, there is no public replaceURL API.
         sessionManager.url_$eq(absoluteUrl);
         return true;
+    }
+
+    /**
+     * Returns the router of the node, or {@code null} when there is none. The router context lookup
+     * throws when the node is not inside a routing tree, so it is guarded here to keep
+     * {@link #replace} to its contract of returning false instead of throwing.
+     */
+    private static SessionManager sessionManagerOf(Node node) {
+        try {
+            if (SessionManagerContext.getContext(node) instanceof SessionManager sessionManager) {
+                return sessionManager;
+            }
+        } catch (Exception ex) {
+            LOGGER.fine("No session manager for the node, skipping the address bar sync");
+        }
+        return null;
     }
 
     /**

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
@@ -26,13 +26,9 @@ public final class BrowserUrlSync {
     /**
      * Replaces the URL shown by the browser and updates the router's bookkeeping to match.
      *
-     * <p>The result only states that the Java side preconditions held, the script was submitted and
-     * the router state was updated. Whether the browser executed the script is not confirmed: the
-     * two updates are not atomic.
-     *
      * @param node the node the calling view belongs to
      * @param url  an absolute-path reference within the application, such as {@code /videos?type=library}
-     * @return whether the URL was submitted, so that the caller only records what it submitted
+     * @return whether the script was submitted; the browser's execution of it is not confirmed
      */
     public static boolean replace(Node node, String url) {
         if (!WebAPI.isBrowser() || node == null || node.getScene() == null) {
@@ -71,8 +67,7 @@ public final class BrowserUrlSync {
     }
 
     /**
-     * Builds the script that replaces the URL. Extracted so that a test can assert the exact
-     * script text instead of only the escaping of its argument.
+     * Builds the script that replaces the URL.
      */
     static String buildReplaceScript(String url) {
         return "history.replaceState(history.state, '', " + GSON.toJson(url) + ");";

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
@@ -1,0 +1,121 @@
+package com.dlsc.jfxcentral2.utils;
+
+import com.google.gson.Gson;
+import com.jpro.webapi.WebAPI;
+import javafx.scene.Node;
+import one.jpro.platform.routing.SessionManagerContext;
+import one.jpro.platform.routing.sessionmanager.SessionManager;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Writes the URL of the current filter state into the browser address bar without reloading the
+ * page, and keeps the router's own URL bookkeeping in sync with it.
+ */
+public final class BrowserUrlSync {
+
+    private static final Logger LOGGER = Logger.getLogger(BrowserUrlSync.class.getName());
+    private static final Gson GSON = new Gson();
+    private static final Pattern SEGMENT = Pattern.compile("[A-Za-z0-9._~-]+");
+    private static final Pattern PAIR = Pattern.compile("[^=&]+=[^=&]+");
+
+    private BrowserUrlSync() {
+    }
+
+    /**
+     * Replaces the URL shown by the browser and updates the router's bookkeeping to match.
+     *
+     * <p>The result only states that the Java side preconditions held, the script was submitted and
+     * the router state was updated. Whether the browser executed the script is not confirmed: the
+     * two updates are not atomic.
+     *
+     * @param node the node the calling view belongs to
+     * @param url  an absolute-path reference within the application, such as {@code /videos?type=library}
+     * @return whether the URL was submitted, so that the caller only records what it submitted
+     */
+    public static boolean replace(Node node, String url) {
+        if (!WebAPI.isBrowser() || node == null || node.getScene() == null) {
+            return false;
+        }
+        if (!isSafeUrl(url)) {
+            LOGGER.warning("Refusing to write an unexpected URL to the address bar: " + url);
+            return false;
+        }
+        if (!(SessionManagerContext.getContext(node) instanceof SessionManager sessionManager)
+                || sessionManager.getURL() == null) {
+            return false;
+        }
+        // The router keeps an absolute URL, so the path has to be resolved against it.
+        String absoluteUrl = SessionManager.mergeURLs(sessionManager.getURL(), url);
+        WebAPIUtil.executeScript(node, buildReplaceScript(url));
+        // Scala setter of the router's url var, there is no public replaceURL API.
+        sessionManager.url_$eq(absoluteUrl);
+        return true;
+    }
+
+    /**
+     * Builds the script that replaces the URL. Extracted so that a test can assert the exact
+     * script text instead of only the escaping of its argument.
+     */
+    static String buildReplaceScript(String url) {
+        return "history.replaceState(history.state, '', " + GSON.toJson(url) + ");";
+    }
+
+    /**
+     * Accepts only an absolute-path reference within this application: no scheme, no authority,
+     * no fragment, no empty or dot segments, only unreserved characters in the path, and a query
+     * string made of {@code name=value} pairs that the router's own parser accepts.
+     */
+    static boolean isSafeUrl(String url) {
+        if (url == null) {
+            return false;
+        }
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException ex) {
+            return false;
+        }
+        if (uri.getScheme() != null || uri.getRawAuthority() != null || uri.getRawFragment() != null) {
+            return false;
+        }
+        return isSafePath(uri.getRawPath()) && isSafeQuery(uri.getRawQuery());
+    }
+
+    private static boolean isSafePath(String path) {
+        if (path == null || !path.startsWith("/") || path.startsWith("//")) {
+            return false;
+        }
+        if (path.equals("/")) {
+            return true;
+        }
+        for (String segment : path.substring(1).split("/", -1)) {
+            if (segment.equals(".") || segment.equals("..") || !SEGMENT.matcher(segment).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * The router splits the query on "&" and then expects exactly one "=" per pair, so anything
+     * else would make the page fail to load after a refresh or a back navigation.
+     */
+    private static boolean isSafeQuery(String rawQuery) {
+        if (rawQuery == null) {
+            return true;
+        }
+        if (rawQuery.isEmpty()) {
+            return false;
+        }
+        for (String pair : rawQuery.split("&", -1)) {
+            if (!PAIR.matcher(pair).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/BrowserUrlSync.java
@@ -8,7 +8,6 @@ import one.jpro.platform.routing.sessionmanager.SessionManager;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 /**
@@ -17,7 +16,6 @@ import java.util.regex.Pattern;
  */
 public final class BrowserUrlSync {
 
-    private static final Logger LOGGER = Logger.getLogger(BrowserUrlSync.class.getName());
     private static final Gson GSON = new Gson();
     private static final Pattern SEGMENT = Pattern.compile("[A-Za-z0-9._~-]+");
     private static final Pattern PAIR = Pattern.compile("[^=&]+=[^=&]+");
@@ -41,7 +39,7 @@ public final class BrowserUrlSync {
             return false;
         }
         if (!isSafeUrl(url)) {
-            LOGGER.warning("Refusing to write an unexpected URL to the address bar: " + url);
+            LOGGER.warn("Refusing to write an unexpected URL to the address bar: ", url);
             return false;
         }
         SessionManager sessionManager = sessionManagerOf(node);
@@ -67,7 +65,7 @@ public final class BrowserUrlSync {
                 return sessionManager;
             }
         } catch (Exception ex) {
-            LOGGER.fine("No session manager for the node, skipping the address bar sync");
+            // No routing context for this node, which is an expected case off the router tree.
         }
         return null;
     }

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/PageRequest.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/PageRequest.java
@@ -1,0 +1,31 @@
+package com.dlsc.jfxcentral2.utils;
+
+import one.jpro.platform.routing.Request;
+
+/**
+ * The part of a routing request that a page needs: the path it was reached by and its decoded
+ * query parameters.
+ *
+ * @param path   the request path without the query string, for example {@code /videos}
+ * @param params the decoded query parameters
+ */
+public record PageRequest(String path, QueryParams params) {
+
+    /**
+     * A request without any parameter, used by callers that create a page outside of the router.
+     */
+    public static final PageRequest EMPTY = new PageRequest("/", QueryParams.EMPTY);
+
+    /**
+     * Creates an instance from a routing request.
+     *
+     * @param request the routing request, may be {@code null}
+     * @return the page request, never {@code null}
+     */
+    public static PageRequest of(Request request) {
+        if (request == null) {
+            return EMPTY;
+        }
+        return new PageRequest(request.getPath(), QueryParams.of(request.getQueryParameters()));
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/PageRequest.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/PageRequest.java
@@ -3,29 +3,36 @@ package com.dlsc.jfxcentral2.utils;
 import one.jpro.platform.routing.Request;
 
 /**
- * The part of a routing request that a page needs: the path it was reached by and its decoded
- * query parameters.
+ * The part of a routing request that a page needs: the canonical path the route was registered
+ * under and the decoded query parameters.
  *
- * @param path   the request path without the query string, for example {@code /videos}
+ * <p>The path is deliberately not taken from the request. It is written back to the browser
+ * address bar, so it has to be a value the application controls, such as a {@code PagePath}
+ * constant or a constant plus an id that was validated against the repository.
+ *
+ * @param path   the canonical path of the page, for example {@code /videos}; {@code null} when the
+ *               page was not created by a registered route, which disables the address bar sync
  * @param params the decoded query parameters
  */
 public record PageRequest(String path, QueryParams params) {
 
     /**
-     * A request without any parameter, used by callers that create a page outside of the router.
+     * A request without a canonical path or any parameter, used by callers that create a page
+     * outside of the router.
      */
-    public static final PageRequest EMPTY = new PageRequest("/", QueryParams.EMPTY);
+    public static final PageRequest EMPTY = new PageRequest(null, QueryParams.EMPTY);
 
     /**
      * Creates an instance from a routing request.
      *
-     * @param request the routing request, may be {@code null}
+     * @param request       the routing request, may be {@code null}
+     * @param canonicalPath the path the route was registered under, never derived from the request
      * @return the page request, never {@code null}
      */
-    public static PageRequest of(Request request) {
+    public static PageRequest of(Request request, String canonicalPath) {
         if (request == null) {
             return EMPTY;
         }
-        return new PageRequest(request.getPath(), QueryParams.of(request.getQueryParameters()));
+        return new PageRequest(canonicalPath, QueryParams.of(request.getQueryParameters()));
     }
 }

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
@@ -36,10 +36,7 @@ public final class QueryParams {
     /**
      * Creates an instance from the raw, still encoded parameters of a request.
      *
-     * <p>A value that cannot be decoded is dropped and the remaining parameters are kept. Values
-     * arriving through the router have already passed the percent-escape validation of
-     * {@code java.net.URI}, so this is a safeguard for direct callers rather than a fix for a
-     * reachable failure.
+     * <p>A value that cannot be decoded is dropped and the remaining parameters are kept.
      *
      * @param raw the raw parameters, may be {@code null}
      * @return an instance holding the decoded parameters, never {@code null}

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
@@ -1,0 +1,181 @@
+package com.dlsc.jfxcentral2.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An immutable, decoded view of the query parameters of a page request.
+ *
+ * <p>Parameter names are lower-cased and values are URL-decoded on construction. Matching a
+ * parameter value against a display name is done via {@link #normalize(String)}, which is lenient:
+ * {@code jfxinaction}, {@code jfx-in-action} and {@code JFX%20In%20Action} all match the data value
+ * {@code "JFX In Action"}. Links are generated with the readable form produced by
+ * {@link #toSlug(String)}.
+ */
+public final class QueryParams {
+
+    /**
+     * An instance without any parameter.
+     */
+    public static final QueryParams EMPTY = new QueryParams(Collections.emptyMap());
+
+    private final Map<String, String> params;
+
+    private QueryParams(Map<String, String> params) {
+        this.params = params;
+    }
+
+    /**
+     * Creates an instance from the raw, still encoded parameters of a request.
+     *
+     * <p>A value that cannot be decoded is dropped and the remaining parameters are kept. Values
+     * arriving through the router have already passed the percent-escape validation of
+     * {@code java.net.URI}, so this is a safeguard for direct callers rather than a fix for a
+     * reachable failure.
+     *
+     * @param raw the raw parameters, may be {@code null}
+     * @return an instance holding the decoded parameters, never {@code null}
+     */
+    public static QueryParams of(Map<String, String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return EMPTY;
+        }
+
+        Map<String, String> decoded = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : raw.entrySet()) {
+            String name = entry.getKey();
+            if (StringUtils.isBlank(name)) {
+                continue;
+            }
+            try {
+                decoded.put(name.toLowerCase(Locale.ROOT), decode(entry.getValue()));
+            } catch (IllegalArgumentException ex) {
+                LOGGER.warn("Ignoring query parameter with an undecodable value: ", name);
+            }
+        }
+
+        return decoded.isEmpty() ? EMPTY : new QueryParams(Collections.unmodifiableMap(decoded));
+    }
+
+    private static String decode(String value) {
+        return value == null ? "" : URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Returns the decoded value of the given parameter.
+     *
+     * @param name the parameter name, case-insensitive
+     * @return the value, or an empty optional when the parameter is absent or blank
+     */
+    public Optional<String> get(String name) {
+        if (StringUtils.isBlank(name)) {
+            return Optional.empty();
+        }
+        String value = params.get(name.toLowerCase(Locale.ROOT));
+        return StringUtils.isBlank(value) ? Optional.empty() : Optional.of(value);
+    }
+
+    /**
+     * Returns whether this instance holds no parameter at all.
+     *
+     * @return true if there is no parameter
+     */
+    public boolean isEmpty() {
+        return params.isEmpty();
+    }
+
+    /**
+     * Reduces a value to its comparable form by lower-casing it and dropping everything that is
+     * neither a letter nor a digit. Used to match a parameter value against a display name.
+     *
+     * @param value the value to normalize, may be {@code null}
+     * @return the normalized value, never {@code null}
+     */
+    public static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder(value.length());
+        for (char c : value.toLowerCase(Locale.ROOT).toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Converts a display name into the readable form used when generating links, for example
+     * {@code "JFX In Action"} becomes {@code "jfx-in-action"}.
+     *
+     * @param displayName the display name, may be {@code null}
+     * @return the slug, never {@code null}
+     */
+    public static String toSlug(String displayName) {
+        if (displayName == null) {
+            return "";
+        }
+
+        StringBuilder builder = new StringBuilder(displayName.length());
+        boolean pendingSeparator = false;
+        for (char c : displayName.toLowerCase(Locale.ROOT).toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                if (pendingSeparator && !builder.isEmpty()) {
+                    builder.append('-');
+                }
+                builder.append(c);
+                pendingSeparator = false;
+            } else {
+                pendingSeparator = true;
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Builds a URL from a path and a set of parameters.
+     *
+     * <p>Parameters with a blank value are omitted and values are percent-encoded, which keeps the
+     * result parsable by the router: an empty value or an unencoded {@code =} makes the framework
+     * reject the whole request.
+     *
+     * @param path   the page path, for example {@code /videos}
+     * @param params the parameters to append, may be {@code null}
+     * @return the URL, never {@code null}
+     */
+    public static String buildUrl(String path, Map<String, String> params) {
+        String base = path == null ? "" : path;
+        if (params == null || params.isEmpty()) {
+            return base;
+        }
+
+        StringBuilder builder = new StringBuilder(base);
+        boolean first = true;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String name = entry.getKey();
+            String value = entry.getValue();
+            if (StringUtils.isBlank(name) || StringUtils.isBlank(value)) {
+                continue;
+            }
+            builder.append(first ? '?' : '&');
+            builder.append(encode(name)).append('=').append(encode(value));
+            first = false;
+        }
+        return builder.toString();
+    }
+
+    private static String encode(String value) {
+        // URLEncoder targets form encoding, where a space becomes "+". Inside a query string "%20"
+        // is the safer form because it survives readers that do not apply form decoding.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
+++ b/components/src/main/java/com/dlsc/jfxcentral2/utils/QueryParams.java
@@ -175,7 +175,9 @@ public final class QueryParams {
 
     private static String encode(String value) {
         // URLEncoder targets form encoding, where a space becomes "+". Inside a query string "%20"
-        // is the safer form because it survives readers that do not apply form decoding.
-        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+        // is the safer form because it survives readers that do not apply form decoding. The comma
+        // is left as is: it is a legal query character and keeps multi-value links such as a pack
+        // list readable, and "%2C" is only ever the encoding of a comma so undoing it is exact.
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20").replace("%2C", ",");
     }
 }

--- a/components/src/test/java/com/dlsc/jfxcentral2/utils/QueryParamsTest.java
+++ b/components/src/test/java/com/dlsc/jfxcentral2/utils/QueryParamsTest.java
@@ -1,0 +1,148 @@
+package com.dlsc.jfxcentral2.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the decoding, normalization and URL building of {@link QueryParams}.
+ */
+public class QueryParamsTest {
+
+    private static String normalizedValue(String rawValue) {
+        return QueryParams.normalize(QueryParams.of(Map.of("type", rawValue)).get("type").orElse(""));
+    }
+
+    @Test
+    public void testNormalizeDropsEverythingButLettersAndDigits() {
+        assertEquals("jfxinaction", QueryParams.normalize("JFX In Action"));
+        assertEquals("planningscheduling", QueryParams.normalize("Planning & Scheduling"));
+        assertEquals("", QueryParams.normalize(null));
+    }
+
+    /**
+     * The lenient matching only holds end to end, after the value has been decoded. Calling
+     * normalize on a still encoded value would turn "%20" into "20".
+     */
+    @Test
+    public void testAllSpellingsOfAValueMatchTheSameDataValue() {
+        String expected = QueryParams.normalize("JFX In Action");
+        assertEquals(expected, normalizedValue("jfxinaction"));
+        assertEquals(expected, normalizedValue("jfx-in-action"));
+        assertEquals(expected, normalizedValue("JFX%20In%20Action"));
+        assertEquals(expected, normalizedValue("JFX+In+Action"));
+    }
+
+    @Test
+    public void testToSlugProducesReadableValues() {
+        assertEquals("jfx-in-action", QueryParams.toSlug("JFX In Action"));
+        assertEquals("from-a-to-z", QueryParams.toSlug("From A to Z"));
+        assertEquals("planning-scheduling", QueryParams.toSlug("Planning & Scheduling"));
+        assertEquals("a-z", QueryParams.toSlug("A → Z"));
+        assertEquals("", QueryParams.toSlug(null));
+    }
+
+    /**
+     * The default locale must not influence the result: in Turkish the lower case of "I" is the
+     * dotless "ı", which would make "IONICONS" normalize to something no data value matches.
+     */
+    @Test
+    public void testNormalizeIsLocaleIndependent() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"));
+            assertEquals("ionicons", QueryParams.normalize("IONICONS"));
+            assertEquals("ionicons", QueryParams.toSlug("IONICONS"));
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    public void testParameterNamesAreCaseInsensitive() {
+        QueryParams params = QueryParams.of(Map.of("TYPE", "library"));
+        assertEquals("library", params.get("type").orElse(null));
+        assertEquals("library", params.get("Type").orElse(null));
+    }
+
+    @Test
+    public void testBlankValuesAreTreatedAsAbsent() {
+        QueryParams params = QueryParams.of(Map.of("search", "   "));
+        assertTrue(params.get("search").isEmpty());
+    }
+
+    /**
+     * A value that cannot be decoded is dropped while the other parameters stay usable. Note that
+     * such a value cannot reach this class through the router: the framework rejects the request
+     * while validating the percent escapes of the URI. This only guards direct callers.
+     */
+    @Test
+    public void testUndecodableValueIsDroppedWithoutAffectingTheOthers() {
+        Map<String, String> raw = new LinkedHashMap<>();
+        raw.put("search", "%");
+        raw.put("type", "library");
+
+        QueryParams params = QueryParams.of(raw);
+
+        assertTrue(params.get("search").isEmpty());
+        assertEquals("library", params.get("type").orElse(null));
+    }
+
+    @Test
+    public void testBuildUrlOmitsBlankValues() {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("search", "");
+        params.put("type", "library");
+        params.put("event", null);
+
+        assertEquals("/videos?type=library", QueryParams.buildUrl("/videos", params));
+    }
+
+    @Test
+    public void testBuildUrlWithoutParamsReturnsThePath() {
+        assertEquals("/videos", QueryParams.buildUrl("/videos", null));
+        assertEquals("/videos", QueryParams.buildUrl("/videos", new HashMap<>()));
+    }
+
+    @Test
+    public void testBuildUrlEncodesReservedCharacters() {
+        assertEquals("/videos?search=a%3Db", QueryParams.buildUrl("/videos", Map.of("search", "a=b")));
+        assertEquals("/videos?search=a%26b", QueryParams.buildUrl("/videos", Map.of("search", "a&b")));
+        assertEquals("/videos?search=a%20b", QueryParams.buildUrl("/videos", Map.of("search", "a b")));
+        assertEquals("/videos?search=%E4%B8%AD%E6%96%87", QueryParams.buildUrl("/videos", Map.of("search", "中文")));
+        // comma stays readable (legal query char) and round trips
+        assertEquals("/icons?pack=a,b,c", QueryParams.buildUrl("/icons", Map.of("pack", "a,b,c")));
+        assertEquals("a,b,c", QueryParams.of(Map.of("pack", "a,b,c")).get("pack").orElse(null));
+    }
+
+    /**
+     * A generated URL has to survive URI parsing: a bare percent sign makes the URI constructor
+     * reject the whole request, so it must come out encoded and decode back to the original.
+     */
+    @Test
+    public void testGeneratedUrlSurvivesUriParsingAndDecodesBack() {
+        String url = QueryParams.buildUrl("/videos", Map.of("search", "100%"));
+        assertEquals("/videos?search=100%25", url);
+
+        URI uri = URI.create(url);
+        assertEquals("/videos", uri.getPath());
+        assertEquals("100%", URLDecoder.decode(uri.getRawQuery().split("=")[1], StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testEmptyInstances() {
+        assertTrue(QueryParams.EMPTY.isEmpty());
+        assertTrue(QueryParams.of(null).isEmpty());
+        assertTrue(QueryParams.of(new HashMap<>()).isEmpty());
+        assertTrue(QueryParams.EMPTY.get("search").isEmpty());
+    }
+}


### PR DESCRIPTION
ISSUE #606

  ## Why                                                                                                                                                                                                                                               
  Users could not share a link to a specific filter selection. This makes the                                                                                                                                                                          
  filter, search and sort state of a page expressible as a URL — in both                                                                                                                                                                               
  directions.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                       
  ## What                                                                                                                                                                                                                                              
  - **Inbound**: opening a URL with query parameters preselects the matching                                                                                                                                                                           
    filters, search text and sort order.                                                                                                                                                                                                               
  - **Outbound**: changing a filter, the search field or the sort order rewrites                                                                                                                                                                       
    the address bar in place (`history.replaceState`, no reload), so the URL always                                                                                                                                                                    
    reflects the current view. Going back from a detail page returns to the                                                                                                                                                                            
    filtered list.                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                       
  ## Supported parameters                                                                                                                                                                                                                              
  - Category pages: `search`, `sort`, and one per filter group (`type`, `event`,                                                                                                                                                                       
    `domain`, `style`, `date`, `label`, `status`).                                                                                                                                                                                                     
  - Icons page: `scope`, `pack`, `sort`, `search`.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                       
  Values match leniently (case, hyphens, percent-encoding); Unknown or invalid values fall back to the actual UI state. When the user then changes a filter, search, or sort option, the address bar is rewritten to a canonical URL containing only the effective, supported state. A directly-opened URL is left untouched until that first change.                                                                                                                                                                                 
                                                                                                                                                                                                                                                       
  ## Notes                                                                                                                                                                                                                                             
  - Written-back URLs are validated and JSON-serialized before injection.                                                                                                                                                                              
  - Multi-step browser Back is constrained by JPro's own history handling (the same                                                                                                                                                                    
    as in production); the filter → detail → Back case works.      
    
    
    ## Demo
    
    **/videos?domain=gaming**
   
<img width="600" height="439" alt="image" src="https://github.com/user-attachments/assets/126bbcb8-a69e-4158-b914-6df4503e5642" />


**/libraries?search=controls&sort=za**
<img width="600" height="428" alt="image" src="https://github.com/user-attachments/assets/b1e6e1c3-d830-4c57-b1bf-ccaa92ad645c" />
